### PR TITLE
fix: add `target` pathname currectly

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -84,7 +84,7 @@ export function setupOutgoing(outgoing, options, req, forward?) {
   // the final path is target path + relative path requested by user:
   const target = options[forward || "target"];
   const targetPath =
-    target && options.prependPath !== false ? target.path || "" : "";
+    target && options.prependPath !== false ? target.pathname || "" : "";
 
   const parsed = new URL(req.url, "http://localhost");
   let outgoingPath = options.toProxy

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -84,7 +84,9 @@ export function setupOutgoing(outgoing, options, req, forward?) {
   // the final path is target path + relative path requested by user:
   const target = options[forward || "target"];
   const targetPath =
-    target && options.prependPath !== false ? target.pathname || "" : "";
+    target && options.prependPath !== false
+      ? target.pathname || target.path || ""
+      : "";
 
   const parsed = new URL(req.url, "http://localhost");
   let outgoingPath = options.toProxy

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -28,7 +28,7 @@ describe("httpxy", () => {
       lastResolved = false;
       lastRejected = undefined;
       try {
-        await proxy.web(req, res, { target: mainListener.url });
+        await proxy.web(req, res, { target: mainListener.url + "base" });
         lastResolved = true;
       } catch (error) {
         lastRejected = error;
@@ -39,8 +39,8 @@ describe("httpxy", () => {
   });
 
   it("works", async () => {
-    const mainResponse = await $fetch(mainListener.url + "?foo");
-    const proxyResponse = await $fetch(proxyListener.url + "?foo");
+    const mainResponse = await $fetch(mainListener.url + "base/test?foo");
+    const proxyResponse = await $fetch(proxyListener.url + "test?foo");
 
     const maskResponse = (obj: any) => ({
       ...obj,
@@ -50,6 +50,8 @@ describe("httpxy", () => {
     expect(maskResponse(await mainResponse)).toMatchObject(
       maskResponse(proxyResponse),
     );
+
+    expect(proxyResponse.path).toBe("/base/test?foo");
 
     expect(lastResolved).toBe(true);
     expect(lastRejected).toBe(undefined);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#5 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Sets the correct target path by using the `pathname` property on the URL object as described in the linked issue. While the static type of the `target` object from which I got the `pathname` is `any`, it was in fact an URL object during my limited runtime debugging. However, I don't know if this is always the case, so feel free to correct me or come up with a more complete solution 🙂 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
