### PR TITLE
fix: handle client `close` event

### DIFF
--- a/src/middleware/web-incoming.ts
+++ b/src/middleware/web-incoming.ts
@@ -154,6 +154,9 @@ const stream = defineProxyMiddleware(
           server.emit("end", req, res, proxyRes);
         }
       } else {
+        res.on('close', function () {
+          proxyRes.destroy()
+        });
         // Allow us to listen when the proxy has completed
         proxyRes.on("end", function () {
           if (server) {

--- a/src/middleware/web-incoming.ts
+++ b/src/middleware/web-incoming.ts
@@ -154,6 +154,7 @@ const stream = defineProxyMiddleware(
           server.emit("end", req, res, proxyRes);
         }
       } else {
+        // EventSource close
         res.on("close", function () {
           proxyRes.destroy();
         });

--- a/src/middleware/web-incoming.ts
+++ b/src/middleware/web-incoming.ts
@@ -154,8 +154,8 @@ const stream = defineProxyMiddleware(
           server.emit("end", req, res, proxyRes);
         }
       } else {
-        res.on('close', function () {
-          proxyRes.destroy()
+        res.on("close", function () {
+          proxyRes.destroy();
         });
         // Allow us to listen when the proxy has completed
         proxyRes.on("end", function () {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Downstream discussion: https://github.com/nuxt/nuxt/discussions/16046

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Proxy respond did not get 'abort/destroy' when the client close the request, causing situation in Server sent event where user trigger `close` from the clinet EventSource, but the server request did not trigger the `close` listen as expected.

Reproduction: https://stackblitz.com/edit/unjs-nitro-khtcjd?file=routes%2Fsse.ts
Server Sent Event(SSE) example code: https://gist.github.com/Atinux/05836469acca9649fa2b9e865df898a2

Downstream discussion: https://github.com/nuxt/nuxt/discussions/16046
Related issues: https://github.com/http-party/node-http-proxy/issues/1520
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
