### PR TITLE
types: make httpxy's server event type map generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/async": "^3.2.25",
     "@types/concat-stream": "^2.0.3",
+    "@types/express": "^5.0.6",
     "@types/node": "^25.2.2",
     "@types/sse": "^0.0.0",
     "@types/ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/concat-stream':
         specifier: ^2.0.3
         version: 2.0.3
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^25.2.2
         version: 25.2.2
@@ -886,11 +889,17 @@ packages:
   '@types/async@3.2.25':
     resolution: {integrity: sha512-O6Th/DI18XjrL9TX8LO9F/g26qAz5vynmQqlXt/qLGrskvzCKXKc5/tATz3G2N6lM8eOf3M8/StB14FncAmocg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/concat-stream@2.0.3':
     resolution: {integrity: sha512-3qe4oQAPNwVNwK4C9c8u+VJqv9kez+2MR4qJpoPFfXtgxxif1QbFusvXzK0/Wra2VX07smostI2VMmJNSpZjuQ==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -907,6 +916,15 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -919,8 +937,20 @@ packages:
   '@types/node@25.2.2':
     resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/sse@0.0.0':
     resolution: {integrity: sha512-5gFwbzDsaCze6/SYNwOmk/F24+gtXwTX3at12rJMDo7+VLi3jI83j5h5IkdXEvGakTkVIF9VQBxWOensz+LBWQ==}
@@ -3111,12 +3141,21 @@ snapshots:
 
   '@types/async@3.2.25': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.2.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
   '@types/concat-stream@2.0.3':
+    dependencies:
+      '@types/node': 25.2.2
+
+  '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.2.2
 
@@ -3134,6 +3173,21 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.2.2
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -3146,7 +3200,20 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/resolve@1.20.2': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.2.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.2.2
 
   '@types/sse@0.0.0':
     dependencies:

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,55 +8,34 @@ import { type ProxyServerOptions, type ProxyTarget } from "./types";
 import { ProxyMiddleware, type ResOfType } from "./middleware/_utils";
 import type net from "node:net";
 
-export interface ProxyServerEventMap {
-  error: [
-    err: Error,
-    req?: http.IncomingMessage,
-    res?: http.ServerResponse<http.IncomingMessage> | net.Socket,
-    target?: URL | ProxyTarget,
-  ];
-  start: [
-    req: http.IncomingMessage,
-    res: http.ServerResponse<http.IncomingMessage>,
-    target: URL | ProxyTarget,
-  ];
-  econnreset: [
-    err: Error,
-    req: http.IncomingMessage,
-    res: http.ServerResponse<http.IncomingMessage>,
-    target: URL | ProxyTarget,
-  ];
-  proxyReq: [
-    proxyReq: http.ClientRequest,
-    req: http.IncomingMessage,
-    res: http.ServerResponse<http.IncomingMessage>,
-    options: ProxyServerOptions,
-  ];
+export interface ProxyServerEventMap<
+  Req extends http.IncomingMessage = http.IncomingMessage,
+  Res extends http.ServerResponse = http.ServerResponse,
+> {
+  error: [err: Error, req?: Req, res?: Res | net.Socket, target?: URL | ProxyTarget];
+  start: [req: Req, res: Res, target: URL | ProxyTarget];
+  econnreset: [err: Error, req: Req, res: Res, target: URL | ProxyTarget];
+  proxyReq: [proxyReq: http.ClientRequest, req: Req, res: Res, options: ProxyServerOptions];
   proxyReqWs: [
     proxyReq: http.ClientRequest,
-    req: http.IncomingMessage,
+    req: Req,
     socket: net.Socket,
     options: ProxyServerOptions,
     head: any,
   ];
-  proxyRes: [
-    proxyRes: http.IncomingMessage,
-    req: http.IncomingMessage,
-    res: http.ServerResponse<http.IncomingMessage>,
-  ];
-  end: [
-    req: http.IncomingMessage,
-    res: http.ServerResponse<http.IncomingMessage>,
-    proxyRes: http.IncomingMessage,
-  ];
+  proxyRes: [proxyRes: Req, req: Req, res: Res];
+  end: [req: Req, res: Res, proxyRes: Req];
   open: [proxySocket: net.Socket];
   /** @deprecated */
   proxySocket: [proxySocket: net.Socket];
-  close: [proxyRes: http.IncomingMessage, proxySocket: net.Socket, proxyHead: any];
+  close: [proxyRes: Req, proxySocket: net.Socket, proxyHead: any];
 }
 
 // eslint-disable-next-line unicorn/prefer-event-target
-export class ProxyServer extends EventEmitter<ProxyServerEventMap> {
+export class ProxyServer<
+  Req extends http.IncomingMessage = http.IncomingMessage,
+  Res extends http.ServerResponse = http.ServerResponse,
+> extends EventEmitter<ProxyServerEventMap<Req, Res>> {
   private _server?: http.Server | https.Server;
 
   _webPasses: ProxyMiddleware<http.ServerResponse>[] = [...webIncomingMiddleware];

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,8 +23,8 @@ export interface ProxyServerEventMap<
     options: ProxyServerOptions,
     head: any,
   ];
-  proxyRes: [proxyRes: Req, req: Req, res: Res];
-  end: [req: Req, res: Res, proxyRes: Req];
+  proxyRes: [proxyRes: http.IncomingMessage, req: Req, res: Res];
+  end: [req: Req, res: Res, proxyRes: http.IncomingMessage];
   open: [proxySocket: net.Socket];
   /** @deprecated */
   proxySocket: [proxySocket: net.Socket];

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -5,12 +5,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 describe("httpxy types", () => {
   it("ProxyServer generic types", () => {
-    assertType<ProxyServer>(
-      new ProxyServer(),
-    );
-    assertType<ProxyServer<IncomingMessage, ServerResponse>>(
-      new ProxyServer(),
-    );
+    assertType<ProxyServer>(new ProxyServer());
+    assertType<ProxyServer<IncomingMessage, ServerResponse>>(new ProxyServer());
     assertType<ProxyServer<ExpressRequest, ExpressResponse>>(
       new ProxyServer<ExpressRequest, ExpressResponse>(),
     );

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,18 @@
+import { assertType, describe, it } from "vitest";
+import { ProxyServer } from "../src/server";
+import type { Request as ExpressRequest, Response as ExpressResponse } from "express";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+describe("httpxy types", () => {
+  it("ProxyServer generic types", () => {
+    assertType<ProxyServer>(
+      new ProxyServer(),
+    );
+    assertType<ProxyServer<IncomingMessage, ServerResponse>>(
+      new ProxyServer(),
+    );
+    assertType<ProxyServer<ExpressRequest, ExpressResponse>>(
+      new ProxyServer<ExpressRequest, ExpressResponse>(),
+    );
+  });
+});

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, it } from "vitest";
+import { assertType, describe, expectTypeOf, it } from "vitest";
 import { ProxyServer } from "../src/server";
 import type { Request as ExpressRequest, Response as ExpressResponse } from "express";
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -14,11 +14,11 @@ describe("httpxy types", () => {
     const expressProxyServer = new ProxyServer<ExpressRequest, ExpressResponse>();
 
     expressProxyServer.on("start", (req, res) => {
-      assertType<ExpressRequest>(req);
-      assertType<IncomingMessage>(req);
+      expectTypeOf(req).toEqualTypeOf<ExpressRequest>();
+      expectTypeOf(req).toExtend<IncomingMessage>();
 
-      assertType<ExpressResponse>(res);
-      assertType<ServerResponse>(res);
+      expectTypeOf(res).toEqualTypeOf<ExpressResponse>();
+      expectTypeOf(res).toExtend<ServerResponse>();
     });
   });
 });

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -10,5 +10,15 @@ describe("httpxy types", () => {
     assertType<ProxyServer<ExpressRequest, ExpressResponse>>(
       new ProxyServer<ExpressRequest, ExpressResponse>(),
     );
+
+    const expressProxyServer = new ProxyServer<ExpressRequest, ExpressResponse>();
+
+    expressProxyServer.on("start", (req, res) => {
+      assertType<ExpressRequest>(req);
+      assertType<IncomingMessage>(req);
+
+      assertType<ExpressResponse>(res);
+      assertType<ServerResponse>(res);
+    });
   });
 });


### PR DESCRIPTION
Turns out that we don't have to limit to `http.IncomingMessage` and `http.ServerResponse`. Any types that extend `http.IncomingMessage` and `http.ServerResponse` (e.g., `express.Request` and `express.Response`) should also be allowed.

The PR adds two optional generic types (`Req` and `Res`) to `ProxyServer` for working with Express.

Since `Req` and `Res` are optional and default to `http.IncomingMessage` and `http.ServerResponse`, there is no breaking change.

The PR also adds `vitest`'s `assertType` to test the types and behavior.