### PR TITLE
feat(server): `listeningCallback`

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,7 @@ export class ProxyServer<
    * A function that wraps the object in a webserver, for your convenience
    * @param port - Port to listen on
    * @param hostname - The hostname to listen on
+   * @param listeningListener - A callback function that is called when the server starts listening
    */
   listen(port: number, hostname?: string, listeningListener?: () => void) {
     const closure = (

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,7 @@ export class ProxyServer<
    * @param port - Port to listen on
    * @param hostname - The hostname to listen on
    */
-  listen(port: number, hostname?: string) {
+  listen(port: number, hostname?: string, listeningListener?: () => void) {
     const closure = (
       req: http.IncomingMessage | http2.Http2ServerRequest,
       res: http.ServerResponse | http2.Http2ServerResponse,
@@ -92,7 +92,7 @@ export class ProxyServer<
       });
     }
 
-    this._server.listen(port, hostname);
+    this._server.listen(port, hostname, listeningListener);
 
     return this;
   }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { createProxyServer, ProxyServer } from "../src/index.ts";
@@ -23,10 +23,17 @@ describe("ProxyServer", () => {
       const sourcePort = (source.address() as AddressInfo).port;
 
       proxy = createProxyServer({ target: `http://127.0.0.1:${sourcePort}` });
-      proxy.listen(0, "127.0.0.1");
+
+      const cb = vi.fn();
+
+      proxy.listen(0, "127.0.0.1", cb);
 
       // Wait for the server to be ready
       await new Promise<void>((r) => setTimeout(r, 50));
+
+      expect(cb).toHaveBeenCalledOnce();
+      expect(cb).toHaveBeenCalledWith();
+
       const proxyPort = ((proxy as any)._server.address() as AddressInfo).port;
 
       const res = await fetch(`http://127.0.0.1:${proxyPort}/`);


### PR DESCRIPTION
- https://github.com/http-party/node-http-proxy/issues/1143
- https://github.com/http-party/node-http-proxy/pull/1144

This is part of #2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The server listen method now accepts an optional callback parameter. When supplied, this callback is invoked once the server has successfully started listening and is operational.

* **Tests**
  * Added/updated tests to verify the optional callback is invoked exactly once with no arguments when the server starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->