### PR TITLE
fix: use `agents: false` for ws upgrade

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -116,8 +116,9 @@ export function setupOutgoing(
 
   if (options.agent !== undefined) {
     outgoing.agent = options.agent || false;
-  } else if (req.httpVersionMajor > 1) {
-    // HTTP/2 incoming requests: keep-alive agents can conflict with stream lifecycle
+  } else if (req.httpVersionMajor > 1 || upgradeHeader.test(req.headers.connection || "")) {
+    // WebSocket upgrades and HTTP/2 incoming requests: agents conflict with
+    // the socket lifecycle (upgrade handoff / stream multiplexing).
     outgoing.agent = false;
   } else {
     // Use default keep-alive agents for connection reuse

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -196,6 +196,21 @@ describe("lib/http-proxy/common.js", () => {
       expect(outgoing.agent).to.eql(false);
     });
 
+    it("should not use keep-alive agent for websocket upgrade requests", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        { target: "http://localhost" },
+        stubIncomingMessage({
+          url: "/",
+          headers: { connection: "Upgrade", upgrade: "websocket" },
+        }),
+      );
+      // WebSocket upgrades take ownership of the socket after 101,
+      // so a keep-alive agent must not be used.
+      expect(outgoing.agent).to.eql(false);
+    });
+
     it("set the port according to the protocol", () => {
       const outgoing = createOutgoing();
       common.setupOutgoing(


### PR DESCRIPTION
websocket upgrade connections shouldn't have keep-alive set....

this causes isssues with deno - spotted in https://github.com/nuxt/cli/pull/1284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* WebSocket upgrade requests now properly disable keep-alive agent handling, ensuring consistent behavior with HTTP/2 connection management.

## Tests
* Added test coverage for WebSocket upgrade request handling to validate agent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->