### PR TITLE
fix: do not set undefined values for headers

### DIFF
--- a/src/middleware/web-incoming.ts
+++ b/src/middleware/web-incoming.ts
@@ -47,7 +47,7 @@ export const XHeaders = defineProxyMiddleware((req, res, options) => {
 
   for (const header of ["for", "port", "proto"] as const) {
     const key = "x-forwarded-" + header;
-    if (!req.headers[key]) {
+    if (!req.headers[key] && values[header] !== undefined) {
       req.headers[key] = values[header];
     }
   }

--- a/src/middleware/ws-incoming.ts
+++ b/src/middleware/ws-incoming.ts
@@ -36,7 +36,7 @@ export const XHeaders = defineProxyMiddleware<Socket>((req, socket, options) => 
 
   for (const header of ["for", "port", "proto"] as const) {
     const key = "x-forwarded-" + header;
-    if (!req.headers[key]) {
+    if (!req.headers[key] && values[header] !== undefined) {
       req.headers[key] = values[header];
     }
   }


### PR DESCRIPTION
issue introduced in 1aba9fb - previously headers were coerced to a string but afterwards it became possible to set to `undefined` directly, which deno chokes on