### PR TITLE
feat: forward target URL as the 4th argument in error events

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -234,9 +234,9 @@ function _createProxyFn<
             http.ServerResponse | http2.Http2ServerResponse
           >,
           head,
-          (error) => {
+          (error, _req, _res, url) => {
             if (server.listenerCount("error") > 0) {
-              server.emit("error", error, req, res as ProxyServerRes | net.Socket);
+              server.emit("error", error, req, res as ProxyServerRes | net.Socket, url);
               _resolve();
             } else {
               _reject(error);
@@ -245,7 +245,13 @@ function _createProxyFn<
         );
       } catch (error) {
         if (server.listenerCount("error") > 0) {
-          server.emit("error", error as Error, req, res as ProxyServerRes | net.Socket);
+          server.emit(
+            "error",
+            error as Error,
+            req,
+            res as ProxyServerRes | net.Socket,
+            requestOptions.target,
+          );
           _resolve();
         } else {
           _reject(error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -250,7 +250,7 @@ function _createProxyFn<
             error as Error,
             req,
             res as ProxyServerRes | net.Socket,
-            requestOptions.target,
+            requestOptions.target || requestOptions.forward,
           );
           _resolve();
         } else {

--- a/test/http-proxy.test.ts
+++ b/test/http-proxy.test.ts
@@ -333,6 +333,34 @@ describe("http-proxy", () => {
 
       await promise.catch(() => {});
     });
+
+    it("should forward the target URL as the 4th argument of the error event", async () => {
+      const target = "http://127.0.0.1:1";
+      const proxy = httpProxy.createProxyServer({ target });
+
+      const { promise, resolve } = Promise.withResolvers<URL | undefined>();
+      proxy.on("error", (_err, _req, _res, url) => {
+        proxy.close(() => {});
+        resolve(url as URL | undefined);
+      });
+
+      const proxyPort = await proxyListen(proxy);
+
+      http
+        .request(
+          {
+            hostname: "127.0.0.1",
+            port: proxyPort,
+            method: "GET",
+          },
+          () => {},
+        )
+        .end();
+
+      const url = await promise;
+      expect(url).toBeInstanceOf(URL);
+      expect((url as URL).href).toBe(new URL(target).href);
+    });
   });
 
   describe("#createProxyServer setting the correct timeout value", () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -182,6 +182,76 @@ describe("middleware pass exceptions", () => {
     }
   });
 
+  it("should forward the target URL as the 4th argument when a pass throws", async () => {
+    const target = await new Promise<{
+      close: () => Promise<void>;
+      url: string;
+    }>((resolve, reject) => {
+      const server = http.createServer((_req, res) => {
+        res.end("ok");
+      });
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as AddressInfo;
+        resolve({
+          close: () =>
+            new Promise<void>((r, j) => {
+              server.close((e) => (e ? j(e) : r()));
+            }),
+          url: `http://127.0.0.1:${port}/`,
+        });
+      });
+    });
+
+    const proxy = createProxyServer({ target: target.url });
+
+    proxy.before("web", "", () => {
+      throw new TypeError("Invalid character in header");
+    });
+
+    const proxyServer = await new Promise<{
+      close: () => Promise<void>;
+      url: string;
+    }>((resolve, reject) => {
+      const server = http.createServer((req, res) => {
+        void proxy.web(req, res);
+      });
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as AddressInfo;
+        resolve({
+          close: () =>
+            new Promise<void>((r, j) => {
+              server.close((e) => (e ? j(e) : r()));
+            }),
+          url: `http://127.0.0.1:${port}/`,
+        });
+      });
+    });
+
+    try {
+      const urlPromise = new Promise<URL | undefined>((resolve) => {
+        proxy.on("error", (_err, _req, res, url) => {
+          resolve(url as URL | undefined);
+          if (res && "writeHead" in res && !res.headersSent) {
+            res.writeHead(502);
+            res.end();
+          }
+        });
+      });
+
+      await $fetch(proxyServer.url, { ignoreResponseError: true }).catch(() => {});
+
+      const url = await urlPromise;
+      expect(url).toBeInstanceOf(URL);
+      expect((url as URL).href).toBe(new URL(target.url).href);
+    } finally {
+      proxy.close();
+      await proxyServer.close();
+      await target.close();
+    }
+  });
+
   it("should reject promise when no error listener and pass throws", async () => {
     const target = await new Promise<{
       close: () => Promise<void>;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -183,51 +183,14 @@ describe("middleware pass exceptions", () => {
   });
 
   it("should forward the target URL as the 4th argument when a pass throws", async () => {
-    const target = await new Promise<{
-      close: () => Promise<void>;
-      url: string;
-    }>((resolve, reject) => {
-      const server = http.createServer((_req, res) => {
-        res.end("ok");
-      });
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const { port } = server.address() as AddressInfo;
-        resolve({
-          close: () =>
-            new Promise<void>((r, j) => {
-              server.close((e) => (e ? j(e) : r()));
-            }),
-          url: `http://127.0.0.1:${port}/`,
-        });
-      });
-    });
+    const target = await listen((_req, res) => res.end("ok"));
 
     const proxy = createProxyServer({ target: target.url });
-
     proxy.before("web", "", () => {
       throw new TypeError("Invalid character in header");
     });
 
-    const proxyServer = await new Promise<{
-      close: () => Promise<void>;
-      url: string;
-    }>((resolve, reject) => {
-      const server = http.createServer((req, res) => {
-        void proxy.web(req, res);
-      });
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const { port } = server.address() as AddressInfo;
-        resolve({
-          close: () =>
-            new Promise<void>((r, j) => {
-              server.close((e) => (e ? j(e) : r()));
-            }),
-          url: `http://127.0.0.1:${port}/`,
-        });
-      });
-    });
+    const proxyServer = await listen((req, res) => proxy.web(req, res));
 
     try {
       const urlPromise = new Promise<URL | undefined>((resolve) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -183,7 +183,9 @@ describe("middleware pass exceptions", () => {
   });
 
   it("should forward the target URL as the 4th argument when a pass throws", async () => {
-    const target = await listen((_req, res) => res.end("ok"));
+    const target = await listen((_req, res) => {
+      res.end("ok");
+    });
 
     const proxy = createProxyServer({ target: target.url });
     proxy.before("web", "", () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


The `error` event listener on a `ProxyServer` only receives `(err, req, res)`, the 4th argument (the `target` URL the proxy was trying to reach) is always `undefined` https://github.com/unjs/httpxy/blob/9dc2425ecb48e8a53c5177f0c2117d5bf2f2827f/src/server.ts#L15.

This breaks consumers that rely on it for logging or error handling. The most visible case is `http-proxy-middleware@4`, whose default `loggerPlugin` produces messages like:

```
[HPM] Error occurred while proxying request 127.0.0.1:51234/my-path to undefined [ENOTFOUND] …
```

instead of showing the actual target (`http://unknown:1234/`).

This matches the original [`http-proxy@1.18.1`](https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/passes/web-incoming.js#L155) behaviour:

his helps resolve webpack-dev-server being able to update http-proxy-middleware, which now uses this package https://github.com/webpack/webpack-dev-server/pull/5663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error event handling to include the proxied target URL as an additional parameter, providing more context when errors are emitted.

* **Tests**
  * Added test coverage for error event handling with target URL parameter.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/httpxy/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->