### PR TITLE
fix: preserve trailing slash when proxying root path to a sub-path target

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -184,8 +184,8 @@ export function joinURL(base: string | undefined, path: string | undefined): str
   if (!base || base === "/") {
     return path || "/";
   }
-  if (!path || path === "/") {
-    return base || "/";
+  if (!path) {
+    return base;
   }
   // eslint-disable-next-line unicorn/prefer-at
   const baseHasTrailing = base[base.length - 1] === "/";

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -609,6 +609,14 @@ describe("lib/http-proxy/common.js", () => {
     it("should concat when base has trailing slash and path has no leading slash", () => {
       expect(common.joinURL("/base/", "path")).to.eql("/base/path");
     });
+
+    it("should preserve trailing slash when path is exactly /", () => {
+      expect(common.joinURL("/maildev", "/")).to.eql("/maildev/");
+    });
+
+    it("should keep a single trailing slash when both base ends and path is /", () => {
+      expect(common.joinURL("/maildev/", "/")).to.eql("/maildev/");
+    });
   });
 
   describe("#rewriteCookieProperty", () => {


### PR DESCRIPTION
Closes #134. The `path === "/"` early-return dropped the slash so `joinURL("/maildev", "/")` returned `"/maildev"` instead of `"/maildev/"`, causing redirect loops with sub-path-mounted upstreams. Treat root-path as a real path and let the trailing/leading slash logic produce the correct join. Per @pi0 in #134 ("PR welcome!").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path joining to correctly preserve single trailing slashes in certain cases.

* **Tests**
  * Added tests to verify trailing-slash handling in URL path operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/httpxy/pull/137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->