### PR TITLE
fix: preserve path when target includes path

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -194,7 +194,7 @@ export function joinURL(base: string | undefined, path: string | undefined): str
   if (!base || base === "/") {
     return path || "/";
   }
-  if (!path) {
+  if (!path || path === "/") {
     return base;
   }
   // eslint-disable-next-line unicorn/prefer-at

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -377,6 +377,19 @@ describe("lib/http-proxy/common.js", () => {
       expect(outgoing.path).to.eql("/?project=example&path=");
     });
 
+    it("should not add trailing slash when target has base path and request path is root", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        {
+          target: URL.parse("http://localhost/api")!,
+        },
+        stubIncomingMessage({ url: "/" }),
+      );
+
+      expect(outgoing.path).to.eql("/api");
+    });
+
     it("should not modify the query string", () => {
       const outgoing = createOutgoing();
       common.setupOutgoing(
@@ -694,12 +707,24 @@ describe("lib/http-proxy/common.js", () => {
       expect(common.joinURL("/base/", "path")).to.eql("/base/path");
     });
 
-    it("should preserve trailing slash when path is exactly /", () => {
-      expect(common.joinURL("/maildev", "/")).to.eql("/maildev/");
+    it("should return base when path is exactly /", () => {
+      expect(common.joinURL("/maildev", "/")).to.eql("/maildev");
     });
 
-    it("should keep a single trailing slash when both base ends and path is /", () => {
+    it("should return base when base ends with slash and path is /", () => {
       expect(common.joinURL("/maildev/", "/")).to.eql("/maildev/");
+    });
+
+    it("should return base when path is empty", () => {
+      expect(common.joinURL("/api", "")).to.eql("/api");
+    });
+
+    it("should join base and nested path", () => {
+      expect(common.joinURL("/api", "/users")).to.eql("/api/users");
+    });
+
+    it("should join base with trailing slash and nested path", () => {
+      expect(common.joinURL("/api/", "/users")).to.eql("/api/users");
     });
   });
 


### PR DESCRIPTION
regression introduced in #137 

fixes #138 

tested patch in https://github.com/chimurai/http-proxy-middleware/pull/1234

When target is configured with path the outgoing path is not preserved:
(in 0.5.2 a trailing slash is added)

Reproduction:
```ts
const app = express()

app.use('/', createProxyMiddleware({
    changeOrigin: true,
    target: `http://localhost:9000/api`,        // <--- configure target with path
}));

app.listen(3000)
```

```txt
0.5.1
curl http://localhost:3000  -> http://localhost:9000/api

0.5.2
curl http://localhost:3000  -> http://localhost:9000/api/

PR
curl http://localhost:3000  -> http://localhost:9000/api
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path resolution to correctly handle root path scenarios in path joining logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/httpxy/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->