### PR TITLE
ci: add ecosystem test for `http-proxy-middleware`

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -1,0 +1,15 @@
+name: ecosystem
+on:
+  push:
+    branches: [main, ci/hpm]
+  workflow_dispatch:
+jobs:
+  http-proxy-middleware:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: npm i -fg corepack && corepack enable
+      - uses: actions/setup-node@v6
+        with: { node-version: lts/*, cache: "pnpm" }
+      - run: pnpm install
+      - run: pnpm test:ecosystem http-proxy-middleware

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ pnpm test                         # Lint + typecheck + tests with coverage
 | Format    | `pnpm fmt`       | `oxlint --fix` + `oxfmt`                      |
 | Typecheck | `pnpm typecheck` | `tsgo --noEmit` (native TS preview)           |
 | Test      | `pnpm test`      | Full: lint + typecheck + vitest with coverage |
+| Ecosystem | `pnpm test:ecosystem [target]` | Builds + `npm pack`s httpxy, clones an upstream consumer in a temp dir, overrides its httpxy dep with the local tarball, and runs its tests. Default target: `http-proxy-middleware`. Env: `KEEP=1` retains temp dirs; `REF=<git-ref>` pins the upstream checkout. Script: [scripts/ecosystem-test.mjs](scripts/ecosystem-test.mjs). |
 
 ## Key Types
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,14 +169,14 @@ pnpm test                         # Lint + typecheck + tests with coverage
 
 ## Tooling
 
-| Tool      | Command          | Notes                                         |
-| --------- | ---------------- | --------------------------------------------- |
-| Build     | `pnpm build`     | Uses `unbuild` → CJS + ESM + types in `dist/` |
-| Dev       | `pnpm dev`       | Vitest watch mode                             |
-| Lint      | `pnpm lint`      | `oxlint` + `oxfmt --check`                    |
-| Format    | `pnpm fmt`       | `oxlint --fix` + `oxfmt`                      |
-| Typecheck | `pnpm typecheck` | `tsgo --noEmit` (native TS preview)           |
-| Test      | `pnpm test`      | Full: lint + typecheck + vitest with coverage |
+| Tool      | Command                        | Notes                                                                                                                                                                                                                                                                                                                                |
+| --------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Build     | `pnpm build`                   | Uses `unbuild` → CJS + ESM + types in `dist/`                                                                                                                                                                                                                                                                                        |
+| Dev       | `pnpm dev`                     | Vitest watch mode                                                                                                                                                                                                                                                                                                                    |
+| Lint      | `pnpm lint`                    | `oxlint` + `oxfmt --check`                                                                                                                                                                                                                                                                                                           |
+| Format    | `pnpm fmt`                     | `oxlint --fix` + `oxfmt`                                                                                                                                                                                                                                                                                                             |
+| Typecheck | `pnpm typecheck`               | `tsgo --noEmit` (native TS preview)                                                                                                                                                                                                                                                                                                  |
+| Test      | `pnpm test`                    | Full: lint + typecheck + vitest with coverage                                                                                                                                                                                                                                                                                        |
 | Ecosystem | `pnpm test:ecosystem [target]` | Builds + `npm pack`s httpxy, clones an upstream consumer in a temp dir, overrides its httpxy dep with the local tarball, and runs its tests. Default target: `http-proxy-middleware`. Env: `KEEP=1` retains temp dirs; `REF=<git-ref>` pins the upstream checkout. Script: [scripts/ecosystem-test.mjs](scripts/ecosystem-test.mjs). |
 
 ## Key Types

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "obuild",
     "dev": "vitest",
+    "test:ecosystem": "node scripts/ecosystem-test.mjs",
     "lint": "oxlint . && oxfmt --check",
     "fmt": "oxlint . --fix && oxfmt",
     "prepack": "pnpm run build",

--- a/scripts/ecosystem-test.mjs
+++ b/scripts/ecosystem-test.mjs
@@ -25,7 +25,7 @@ const TARGETS = {
   "http-proxy-middleware": {
     repo: "https://github.com/chimurai/http-proxy-middleware.git",
     // TODO: revert to default branch once `httpxy-0.5.2` is merged upstream.
-    ref: "httpxy-0.5.2",
+    ref: "master",
     install: "yarn install --ignore-scripts",
     steps: ["yarn build", "yarn test"],
   },

--- a/scripts/ecosystem-test.mjs
+++ b/scripts/ecosystem-test.mjs
@@ -14,13 +14,7 @@
 //   REF=<ref>   Git ref to check out from the upstream repo (branch/tag/sha).
 
 import { execSync } from "node:child_process";
-import {
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -92,7 +86,7 @@ const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 const fileSpec = `file:${tarballPath}`;
 if (pkg.dependencies?.httpxy) pkg.dependencies.httpxy = fileSpec;
 if (pkg.devDependencies?.httpxy) pkg.devDependencies.httpxy = fileSpec;
-pkg.resolutions = { ...(pkg.resolutions || {}), httpxy: fileSpec };
+pkg.resolutions = { ...pkg.resolutions, httpxy: fileSpec };
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 console.log(`\nPatched ${pkgPath} to use ${fileSpec}`);
 

--- a/scripts/ecosystem-test.mjs
+++ b/scripts/ecosystem-test.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Ecosystem test runner: builds & packs httpxy, clones an upstream consumer
+// in a temp dir, installs deps with the local tarball overriding the published
+// httpxy version, and runs the consumer's test suite.
+//
+// Usage:
+//   node scripts/ecosystem-test.mjs [target]
+//
+// Targets:
+//   http-proxy-middleware (default)
+//
+// Env:
+//   KEEP=1      Keep temp dirs after run for debugging.
+//   REF=<ref>   Git ref to check out from the upstream repo (branch/tag/sha).
+
+import { execSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const TARGETS = {
+  "http-proxy-middleware": {
+    repo: "https://github.com/chimurai/http-proxy-middleware.git",
+    // TODO: revert to default branch once `httpxy-0.5.2` is merged upstream.
+    ref: "httpxy-0.5.2",
+    install: "yarn install --ignore-scripts",
+    steps: ["yarn build", "yarn test"],
+  },
+};
+
+const targetName = process.argv[2] || "http-proxy-middleware";
+const target = TARGETS[targetName];
+if (!target) {
+  console.error(`Unknown target: ${targetName}`);
+  console.error(`Available: ${Object.keys(TARGETS).join(", ")}`);
+  process.exit(1);
+}
+
+const KEEP = process.env.KEEP === "1";
+const REF = process.env.REF;
+
+const packDir = mkdtempSync(join(tmpdir(), "httpxy-pack-"));
+const workDir = mkdtempSync(join(tmpdir(), `httpxy-eco-${targetName}-`));
+const upstreamDir = join(workDir, targetName);
+
+const cleanup = () => {
+  if (KEEP) {
+    console.log(`\n(KEEP=1) Leaving artifacts:`);
+    console.log(`  pack:     ${packDir}`);
+    console.log(`  upstream: ${upstreamDir}`);
+    return;
+  }
+  rmSync(packDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+};
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => process.exit(130));
+
+const run = (cmd, cwd = ROOT) => {
+  console.log(`\n$ (${cwd === ROOT ? "httpxy" : targetName}) ${cmd}`);
+  execSync(cmd, { stdio: "inherit", cwd });
+};
+
+// 1. Build httpxy and pack into a tarball
+run("pnpm build");
+run(`npm pack --pack-destination ${packDir}`);
+const tarball = readdirSync(packDir).find((f) => f.endsWith(".tgz"));
+if (!tarball) {
+  throw new Error(`No tarball produced in ${packDir}`);
+}
+const tarballPath = join(packDir, tarball);
+console.log(`\nPacked: ${tarballPath}`);
+
+// 2. Clone upstream consumer at a shallow depth
+const ref = REF || target.ref;
+const branchArg = ref ? `--branch ${ref} ` : "";
+run(`git clone --depth 1 ${branchArg}${target.repo} ${upstreamDir}`);
+
+// 3. Pin httpxy to the local tarball via deps + yarn `resolutions`
+const pkgPath = join(upstreamDir, "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+const fileSpec = `file:${tarballPath}`;
+if (pkg.dependencies?.httpxy) pkg.dependencies.httpxy = fileSpec;
+if (pkg.devDependencies?.httpxy) pkg.devDependencies.httpxy = fileSpec;
+pkg.resolutions = { ...(pkg.resolutions || {}), httpxy: fileSpec };
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+console.log(`\nPatched ${pkgPath} to use ${fileSpec}`);
+
+// 4. Install deps and run upstream tests
+run(target.install, upstreamDir);
+for (const step of target.steps) {
+  run(step, upstreamDir);
+}
+
+console.log(`\n✓ ${targetName} tests passed against local httpxy build`);


### PR DESCRIPTION
closes #141

add ecosystem test against https://github.com/chimurai/http-proxy-middleware 

(wip: testing against https://github.com/chimurai/http-proxy-middleware/pull/1234 branch until CI is green & seems `mockttp` related)

/cc @chimurai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ecosystem testing workflow and a new test command to validate integration with downstream projects and run their build/test steps.

* **Documentation**
  * Updated tooling docs to document the ecosystem test command, configuration notes, and usage guidance for running integration checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/httpxy/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->