### PR TITLE
feat: proxyH2Upgrade — RFC 8441 extended-CONNECT WebSocket bridge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export type { ProxyAddr, ProxyServerOptions, ProxyTarget, ProxyTargetDetailed } 
 export { ProxyServer, createProxyServer, type ProxyServerEventMap } from "./server.ts";
 export { proxyFetch, type ProxyFetchOptions } from "./fetch.ts";
 export { proxyUpgrade, type ProxyUpgradeOptions } from "./ws.ts";
+export { proxyH2Upgrade, proxyH2UpgradeSelfLoop, type ProxyH2UpgradeOptions } from "./ws-h2.ts";

--- a/src/ws-h2.ts
+++ b/src/ws-h2.ts
@@ -1,0 +1,347 @@
+import type { IncomingHttpHeaders, ServerHttp2Stream } from "node:http2";
+import { request as httpsRequest } from "node:https";
+import { request as httpRequest } from "node:http";
+import { connect as tlsConnect } from "node:tls";
+import { connect as netConnect } from "node:net";
+import { randomBytes } from "node:crypto";
+import type { ProxyAddr } from "./types.ts";
+import { parseAddr } from "./_utils.ts";
+
+/**
+ * Options for {@link proxyH2Upgrade}.
+ */
+export interface ProxyH2UpgradeOptions {
+  /**
+   * Extra headers to include in the upstream upgrade request.
+   * Default: none.
+   */
+  headers?: Record<string, string>;
+  /**
+   * TLS options forwarded to `https.request`. Use `rejectUnauthorized: false`
+   * for self-signed certs.
+   * Default: none.
+   */
+  ssl?: Record<string, unknown>;
+  /**
+   * Whether to verify upstream TLS certificates.
+   * Default: `true`.
+   */
+  secure?: boolean;
+  /**
+   * Idle timeout (ms) waiting for the upstream's 101 response.
+   * Default: 15_000.
+   */
+  timeout?: number;
+  /**
+   * Override the request path sent upstream.
+   * Default: the h2 stream's `:path` header.
+   */
+  path?: string;
+}
+
+const FORWARD_HEADERS = [
+  "sec-websocket-protocol",
+  "sec-websocket-extensions",
+  "origin",
+  "user-agent",
+];
+
+/**
+ * Bridge a WebSocket-over-HTTP/2 (RFC 8441 extended-CONNECT) stream to an
+ * upstream HTTP/1.1 WebSocket endpoint.
+ *
+ * Listen for `stream` events on an `Http2SecureServer` where
+ * `headers[":method"] === "CONNECT"` and `headers[":protocol"] === "websocket"`,
+ * then hand the stream + headers + target to this function. It opens a fresh
+ * h1.1 `Upgrade` request to the upstream, waits for `101 Switching Protocols`,
+ * and pipes raw bytes between the h2 stream and the upstream socket.
+ *
+ * This complements {@link proxyUpgrade}, which handles the same job for
+ * browsers/clients speaking HTTP/1.1 (with `req.headers.upgrade ==="websocket"`).
+ *
+ * @param addr - Target server address (same shape as {@link proxyUpgrade}).
+ * @param stream - The h2 server stream carrying the extended-CONNECT request.
+ * @param headers - The h2 headers object received with the stream event.
+ * @param opts - Optional proxy options.
+ * @returns A promise resolved once the bridge is set up, rejected on error.
+ *
+ * @example
+ * ```ts
+ * import { proxyH2Upgrade } from "httpxy";
+ * import { createSecureServer } from "node:http2";
+ *
+ * const server = createSecureServer({ key, cert, allowHTTP1: true, settings: { enableConnectProtocol: true } });
+ * server.on("stream", (stream, headers) => {
+ *   if (headers[":method"] === "CONNECT" && headers[":protocol"] === "websocket") {
+ *     proxyH2Upgrade("https://backend:443", stream, headers).catch((err) => {
+ *       stream.respond({ ":status": 502 });
+ *       stream.end();
+ *     });
+ *   }
+ * });
+ * ```
+ */
+export function proxyH2Upgrade(
+  addr: string | ProxyAddr,
+  stream: ServerHttp2Stream,
+  headers: IncomingHttpHeaders,
+  opts: ProxyH2UpgradeOptions = {},
+): Promise<void> {
+  const resolvedAddr = parseAddr(addr);
+  const path = opts.path ?? getHeader(headers, ":path") ?? "/";
+  const useSSL =
+    typeof addr === "string" && !addr.startsWith("unix:")
+      ? new URL(addr).protocol === "https:" || new URL(addr).protocol === "wss:"
+      : false;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    };
+
+    const wsKey = randomBytes(16).toString("base64");
+    const outgoingHeaders: Record<string, string> = {
+      Host: resolvedAddr.host || "localhost",
+      Connection: "Upgrade",
+      Upgrade: "websocket",
+      "Sec-WebSocket-Version": "13",
+      "Sec-WebSocket-Key": wsKey,
+    };
+    for (const h of FORWARD_HEADERS) {
+      const v = getHeader(headers, h);
+      if (v) outgoingHeaders[h] = v;
+    }
+    if (opts.headers) {
+      Object.assign(outgoingHeaders, opts.headers);
+    }
+
+    const doRequest = useSSL ? httpsRequest : httpRequest;
+    const upstreamReq = doRequest({
+      hostname: resolvedAddr.host,
+      port: resolvedAddr.port,
+      path,
+      method: "GET",
+      headers: outgoingHeaders,
+      timeout: opts.timeout ?? 15_000,
+      rejectUnauthorized: opts.secure !== false,
+      ...opts.ssl,
+      socketPath: resolvedAddr.socketPath,
+    });
+
+    upstreamReq.once("timeout", () => {
+      upstreamReq.destroy();
+      settle(new Error(`Upstream did not respond with 101 within ${opts.timeout ?? 15_000}ms`));
+    });
+
+    upstreamReq.once("upgrade", (res, socket, head) => {
+      const respond: Record<string, string | number> = { ":status": 200 };
+      for (const h of ["sec-websocket-protocol", "sec-websocket-extensions"]) {
+        const v = res.headers[h];
+        if (typeof v === "string") respond[h] = v;
+      }
+      try {
+        stream.respond(respond);
+      } catch (err) {
+        socket.destroy();
+        settle(err as Error);
+        return;
+      }
+      if (head?.length) stream.write(head);
+      socket.pipe(stream);
+      stream.pipe(socket);
+      const teardown = () => {
+        socket.destroy();
+        if (!stream.destroyed && !stream.closed) stream.close();
+      };
+      stream.on("close", teardown);
+      socket.on("close", teardown);
+      stream.on("error", teardown);
+      socket.on("error", teardown);
+      settle();
+    });
+
+    upstreamReq.once("response", (res) => {
+      if (settled) return;
+      try {
+        stream.respond({ ":status": res.statusCode || 502 });
+        stream.end();
+      } catch {
+        /* stream already closed */
+      }
+      settle(new Error(`Upstream returned ${res.statusCode} (expected 101)`));
+    });
+
+    upstreamReq.once("error", (err) => {
+      if (settled) return;
+      try {
+        stream.respond({ ":status": 502 });
+        stream.end();
+      } catch {
+        /* stream already closed */
+      }
+      settle(err);
+    });
+
+    upstreamReq.end();
+  });
+}
+
+/**
+ * Bridge a WebSocket-over-HTTP/2 stream back to the same h2 server over a
+ * fresh HTTP/1.1 TLS connection. Useful for in-process WebSocket endpoints
+ * served by middleware that only speaks h1 (webpack-dev-server's HMR is the
+ * canonical case).
+ *
+ * The target host/port are read from the h2 server's `address()`; ALPN is
+ * forced to `http/1.1` so the server's `allowHTTP1: true` path takes over.
+ */
+export function proxyH2UpgradeSelfLoop(
+  h2Server: { address(): { port: number; address?: string } | string | null },
+  stream: ServerHttp2Stream,
+  headers: IncomingHttpHeaders,
+  opts: ProxyH2UpgradeOptions = {},
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    };
+
+    const addr = h2Server.address();
+    if (!addr || typeof addr === "string") {
+      try {
+        stream.respond({ ":status": 502 });
+        stream.end();
+      } catch {
+        /* */
+      }
+      settle(new Error("h2 server has no listening address"));
+      return;
+    }
+
+    const path = opts.path ?? getHeader(headers, ":path") ?? "/";
+    // Self-loop default: skip cert verification — the upstream IS this same
+    // server with whatever cert it was started with (typically dev/self-signed).
+    // Callers can override with `secure: true` if they want to validate.
+    const upstream = tlsConnect({
+      host: "127.0.0.1",
+      port: addr.port,
+      servername: "localhost",
+      ALPNProtocols: ["http/1.1"],
+      rejectUnauthorized: opts.secure === true,
+      ...opts.ssl,
+    });
+    const wsKey = randomBytes(16).toString("base64");
+    let headerBuf = Buffer.alloc(0);
+    let tunneled = false;
+
+    upstream.once("secureConnect", () => {
+      const lines = [
+        `GET ${path} HTTP/1.1`,
+        `Host: ${getHeader(headers, ":authority") || "localhost"}`,
+        `Upgrade: websocket`,
+        `Connection: Upgrade`,
+        `Sec-WebSocket-Version: 13`,
+        `Sec-WebSocket-Key: ${wsKey}`,
+      ];
+      for (const h of ["sec-websocket-protocol", "sec-websocket-extensions", "origin"]) {
+        const v = getHeader(headers, h);
+        if (v) lines.push(`${h}: ${v}`);
+      }
+      lines.push("", "");
+      upstream.write(lines.join("\r\n"));
+    });
+
+    const safeRespond = (status: number, extra?: Record<string, string>) => {
+      if (stream.destroyed || stream.closed) return false;
+      try {
+        stream.respond({ ":status": status, ...extra });
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const onData = (chunk: Buffer) => {
+      if (tunneled || stream.destroyed || stream.closed) {
+        upstream.destroy();
+        return;
+      }
+      headerBuf = Buffer.concat([headerBuf, chunk]);
+      const end = headerBuf.indexOf("\r\n\r\n");
+      if (end < 0) return;
+      const headerText = headerBuf.slice(0, end).toString();
+      const m = headerText.match(/^HTTP\/1\.1 (\d+)/);
+      if (!m || m[1] !== "101") {
+        if (safeRespond(Number(m?.[1]) || 502)) stream.end();
+        upstream.destroy();
+        settle(new Error(`Self-loop upstream returned ${m?.[1] || "no-status"}`));
+        return;
+      }
+      const respond: Record<string, string> = {};
+      for (const line of headerText.split("\r\n").slice(1)) {
+        const kv = line.match(/^([^:]+):\s*(.*)$/);
+        if (!kv || kv[1] === undefined || kv[2] === undefined) continue;
+        const name = kv[1].toLowerCase();
+        if (name === "sec-websocket-protocol" || name === "sec-websocket-extensions") {
+          respond[name] = kv[2];
+        }
+      }
+      tunneled = true;
+      upstream.removeListener("data", onData);
+      if (!safeRespond(200, respond)) {
+        upstream.destroy();
+        settle(new Error("h2 stream closed before tunnel established"));
+        return;
+      }
+      const leftover = headerBuf.slice(end + 4);
+      if (leftover.length) stream.write(leftover);
+      upstream.pipe(stream);
+      stream.pipe(upstream);
+      const teardown = () => {
+        upstream.destroy();
+        if (!stream.destroyed && !stream.closed) stream.close();
+      };
+      stream.on("close", teardown);
+      upstream.on("close", teardown);
+      stream.on("error", teardown);
+      upstream.on("error", teardown);
+      settle();
+    };
+
+    upstream.on("data", onData);
+    upstream.on("error", (err) => {
+      if (!tunneled) {
+        safeRespond(502);
+        try {
+          stream.end();
+        } catch {
+          /* */
+        }
+        settle(err);
+      }
+    });
+  });
+}
+
+function getHeader(headers: IncomingHttpHeaders, key: string): string | undefined {
+  const v = headers[key];
+  if (Array.isArray(v)) return v[0];
+  return typeof v === "string" ? v : undefined;
+}
+
+// netConnect imported for future Unix-socket support; keep the import live.
+void netConnect;

--- a/test/ws-h2.test.ts
+++ b/test/ws-h2.test.ts
@@ -1,0 +1,294 @@
+import { readFileSync } from "node:fs";
+import { createServer, type Server as HttpServer, type IncomingMessage } from "node:http";
+import { type AddressInfo, type Socket } from "node:net";
+import {
+  connect as h2Connect,
+  createSecureServer,
+  type ClientHttp2Session,
+  type Http2SecureServer,
+} from "node:http2";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as ws from "ws";
+
+import { proxyH2Upgrade, proxyH2UpgradeSelfLoop } from "../src/ws-h2.ts";
+
+const tlsOpts = {
+  key: readFileSync(join(__dirname, "fixtures", "agent2-key.pem")),
+  cert: readFileSync(join(__dirname, "fixtures", "agent2-cert.pem")),
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: h1 WebSocket echo server.
+// ---------------------------------------------------------------------------
+let upstreamHttp: HttpServer;
+let upstreamWs: ws.WebSocketServer;
+let upstreamPort: number;
+let lastUpstreamHeaders: Record<string, string | string[] | undefined> = {};
+
+beforeAll(async () => {
+  upstreamHttp = createServer();
+  upstreamWs = new ws.WebSocketServer({ server: upstreamHttp });
+  upstreamWs.on("connection", (socket, req) => {
+    lastUpstreamHeaders = req.headers;
+    socket.on("message", (msg) => socket.send("echo:" + msg.toString("utf8")));
+  });
+  await new Promise<void>((r) => upstreamHttp.listen(0, "127.0.0.1", r));
+  upstreamPort = (upstreamHttp.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  upstreamWs?.close();
+  upstreamHttp?.close();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: spin up an h2 server that uses proxyH2Upgrade on extended-CONNECT.
+// ---------------------------------------------------------------------------
+type H2BridgeFactory = (
+  stream: import("node:http2").ServerHttp2Stream,
+  headers: import("node:http2").IncomingHttpHeaders,
+) => Promise<void>;
+
+async function startH2Bridge(
+  bridge: H2BridgeFactory,
+): Promise<{ server: Http2SecureServer; port: number }> {
+  const server = createSecureServer({
+    ...tlsOpts,
+    allowHTTP1: true,
+    settings: { enableConnectProtocol: true },
+  });
+  // Suppress Node's default 405 for CONNECT — adding any 'connect' listener disables it.
+  server.on("connect", () => {});
+  server.on("stream", (stream, headers) => {
+    // Node's typings for 'stream' on Http2SecureServer use the base Http2Stream;
+    // the runtime value is always a ServerHttp2Stream on a server.
+    const s = stream as import("node:http2").ServerHttp2Stream;
+    if (headers[":method"] === "CONNECT" && headers[":protocol"] === "websocket") {
+      bridge(s, headers).catch(() => {});
+    } else {
+      try {
+        s.respond({ ":status": 404 });
+        s.end();
+      } catch {
+        /* */
+      }
+    }
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  return { server, port };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: open an h2 client, send a WebSocket extended-CONNECT, read the
+// :status response, write a frame, read the echo, return everything.
+// ---------------------------------------------------------------------------
+type H2ClientResult = {
+  status: number;
+  responseHeaders: Record<string, string | string[] | undefined>;
+  // Raw bytes received over the tunnelled stream (after the :status response).
+  body: Buffer;
+};
+
+async function dialAndEcho(
+  proxyPort: number,
+  opts: {
+    path?: string;
+    extraHeaders?: Record<string, string>;
+    writeFrame?: Buffer;
+    waitForBytes?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<H2ClientResult> {
+  const client: ClientHttp2Session = h2Connect(`https://127.0.0.1:${proxyPort}`, {
+    rejectUnauthorized: false,
+  });
+  await new Promise<void>((r) => client.once("connect", () => r()));
+  const headers: Record<string, string> = {
+    ":method": "CONNECT",
+    ":protocol": "websocket",
+    ":path": opts.path ?? "/",
+    ":authority": `127.0.0.1:${proxyPort}`,
+    ...opts.extraHeaders,
+  };
+  const stream = client.request(headers);
+
+  const responsePromise = new Promise<{
+    status: number;
+    responseHeaders: Record<string, string | string[] | undefined>;
+  }>((resolve) => {
+    stream.once("response", (hdrs) => {
+      resolve({
+        status: Number(hdrs[":status"] ?? 0),
+        responseHeaders: hdrs,
+      });
+    });
+  });
+
+  const bodyChunks: Buffer[] = [];
+  let received = 0;
+  const want = opts.waitForBytes ?? 0;
+  const bodyDone = new Promise<void>((resolve) => {
+    if (want === 0) {
+      // Caller doesn't expect bytes — wait for response only.
+      stream.on("end", () => resolve());
+      stream.on("close", () => resolve());
+    } else {
+      stream.on("data", (chunk: Buffer) => {
+        bodyChunks.push(chunk);
+        received += chunk.length;
+        if (received >= want) resolve();
+      });
+      stream.on("end", () => resolve());
+      stream.on("close", () => resolve());
+    }
+  });
+
+  // Wait for the response, then optionally write a frame.
+  const response = await responsePromise;
+  if (opts.writeFrame) stream.write(opts.writeFrame);
+
+  // Wait for echo bytes (or for stream end) with a timeout to keep tests bounded.
+  await Promise.race([bodyDone, new Promise<void>((r) => setTimeout(r, opts.timeoutMs ?? 1000))]);
+
+  try {
+    stream.close();
+  } catch {
+    /* */
+  }
+  client.close();
+  return { ...response, body: Buffer.concat(bodyChunks) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("proxyH2Upgrade", () => {
+  let bridge: { server: Http2SecureServer; port: number };
+
+  afterAll(() => {
+    bridge?.server.close();
+  });
+
+  it("bridges browser h2 extended-CONNECT to an h1 WebSocket upstream and returns :status 200", async () => {
+    bridge = await startH2Bridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${upstreamPort}`, stream, headers),
+    );
+    const r = await dialAndEcho(bridge.port);
+    expect(r.status).toBe(200);
+  });
+
+  it("forwards sec-websocket-protocol / extensions / origin / user-agent to the upstream upgrade request", async () => {
+    bridge = await startH2Bridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${upstreamPort}`, stream, headers),
+    );
+    await dialAndEcho(bridge.port, {
+      extraHeaders: {
+        "sec-websocket-protocol": "chat,superchat",
+        origin: "https://app.example.com",
+        "user-agent": "test-agent/1.0",
+      },
+    });
+    expect(lastUpstreamHeaders["sec-websocket-protocol"]).toBe("chat,superchat");
+    expect(lastUpstreamHeaders["origin"]).toBe("https://app.example.com");
+    expect(lastUpstreamHeaders["user-agent"]).toBe("test-agent/1.0");
+  });
+
+  it("returns :status 502 when the upstream is not listening", async () => {
+    bridge = await startH2Bridge((stream, headers) =>
+      proxyH2Upgrade("http://127.0.0.1:1", stream, headers),
+    );
+    const r = await dialAndEcho(bridge.port, { timeoutMs: 2000 });
+    expect(r.status).toBe(502);
+  });
+
+  it("returns the upstream's non-101 status code when the upstream rejects the upgrade", async () => {
+    // Plain HTTP server that responds 404 to all upgrades.
+    const rejecter = createServer((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+    rejecter.on("upgrade", (_req, socket) => {
+      socket.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+      socket.destroy();
+    });
+    await new Promise<void>((r) => rejecter.listen(0, "127.0.0.1", r));
+    const rejectPort = (rejecter.address() as AddressInfo).port;
+
+    bridge = await startH2Bridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${rejectPort}`, stream, headers),
+    );
+    const r = await dialAndEcho(bridge.port, { timeoutMs: 2000 });
+    expect(r.status).toBe(404);
+
+    rejecter.close();
+  });
+
+  it("uses opts.path when provided instead of the h2 :path header", async () => {
+    let observedPath = "";
+    const sniffer = createServer();
+    sniffer.on("upgrade", (req, socket) => {
+      observedPath = req.url ?? "";
+      socket.destroy();
+    });
+    await new Promise<void>((r) => sniffer.listen(0, "127.0.0.1", r));
+    const sniffPort = (sniffer.address() as AddressInfo).port;
+
+    bridge = await startH2Bridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${sniffPort}`, stream, headers, { path: "/override" }),
+    );
+    await dialAndEcho(bridge.port, { path: "/ignored", timeoutMs: 1000 });
+    expect(observedPath).toBe("/override");
+
+    sniffer.close();
+  });
+});
+
+describe("proxyH2UpgradeSelfLoop", () => {
+  let h2Server: Http2SecureServer;
+  let h2Port: number;
+
+  beforeAll(async () => {
+    h2Server = createSecureServer({
+      ...tlsOpts,
+      allowHTTP1: true,
+      settings: { enableConnectProtocol: true },
+    });
+    // A WebSocket endpoint served by this same process — exposed only to h1.1.
+    const loopWs = new ws.WebSocketServer({ noServer: true });
+    loopWs.on("connection", (socket) => {
+      socket.send("self-loop:hello");
+    });
+    h2Server.on("upgrade", (req: IncomingMessage, socket: Socket, head: Buffer) => {
+      loopWs.handleUpgrade(req, socket, head, (client) => loopWs.emit("connection", client, req));
+    });
+    h2Server.on("connect", () => {});
+    h2Server.on("stream", (stream, headers) => {
+      const s = stream as import("node:http2").ServerHttp2Stream;
+      if (headers[":method"] === "CONNECT" && headers[":protocol"] === "websocket") {
+        proxyH2UpgradeSelfLoop(h2Server, s, headers).catch(() => {});
+        return;
+      }
+      try {
+        s.respond({ ":status": 404 });
+        s.end();
+      } catch {
+        /* */
+      }
+    });
+    await new Promise<void>((r) => h2Server.listen(0, "127.0.0.1", r));
+    h2Port = (h2Server.address() as AddressInfo).port;
+  });
+
+  afterAll(() => {
+    h2Server?.close();
+  });
+
+  it("tunnels an h2 extended-CONNECT back to the same server over h1.1 and receives the greeting", async () => {
+    const r = await dialAndEcho(h2Port, { waitForBytes: 1, timeoutMs: 2000 });
+    expect(r.status).toBe(200);
+    expect(r.body.toString("utf8")).toContain("self-loop:hello");
+  });
+});


### PR DESCRIPTION
## Summary

Adds two functions that complement the existing `proxyUpgrade` (HTTP/1.1 Upgrade) for the RFC 8441 extended-CONNECT path — WebSocket upgrades arriving as HTTP/2 server-streams with `:method: CONNECT` and `:protocol: websocket`. Today there's no way in httpxy (or anywhere else in the Node ecosystem) to bridge these to an h1.1 upstream.

- **`proxyH2Upgrade(addr, stream, headers, opts?)`** — opens a fresh h1.1 `Upgrade` request to the upstream, waits for `101 Switching Protocols`, pipes bytes both ways between the h2 server-stream and the upstream socket. Symmetric in shape with `proxyUpgrade` so users keep one mental model.
- **`proxyH2UpgradeSelfLoop(h2Server, stream, headers, opts?)`** — bridges back to the same h2 server over a fresh TLS connection with ALPN forced to `http/1.1`, so middleware that only speaks h1 (typical bundler-HMR endpoints) keeps working when the front door is h2.

## Motivation

Once you enable h2 + `settings: { enableConnectProtocol: true }` on a Node `Http2SecureServer`, browsers will negotiate WebSocket over h2 via RFC 8441 extended-CONNECT. The upgrade no longer comes through `req.upgrade` — it arrives as a server-stream on the `'stream'` event with the CONNECT pseudo-headers. `proxyUpgrade` doesn't help (it's h1-only by design); raw-socket bridging is non-trivial. This PR fills that exact gap.

Useful for any dev/test proxy that wants the modern `http2: true` listener path AND a WebSocket upstream — e.g. webpack-dev-server or Vite running on h2 in front of an h1 backend.

## Usage

```ts
import { createSecureServer } from \"node:http2\";
import { proxyH2Upgrade, proxyH2UpgradeSelfLoop } from \"httpxy\";

const server = createSecureServer({
  key, cert,
  allowHTTP1: true,
  settings: { enableConnectProtocol: true },
});

// Suppress Node's default 405 on CONNECT; adding any 'connect' listener disables it.
server.on(\"connect\", () => {});

server.on(\"stream\", (stream, headers) => {
  if (headers[\":method\"] !== \"CONNECT\" || headers[\":protocol\"] !== \"websocket\") {
    return; // Other handlers / Node's default response take over.
  }
  const path = String(headers[\":path\"] ?? \"/\");
  if (path.startsWith(\"/ws\") || path.startsWith(\"/__hmr\")) {
    proxyH2UpgradeSelfLoop(server, stream, headers).catch(() => {});
    return;
  }
  proxyH2Upgrade(\"http://backend:8080\", stream, headers).catch(() => {});
});
```

## Tests

Six new tests in `test/ws-h2.test.ts`:

1. h2 extended-CONNECT bridges to an h1 WebSocket upstream and returns `:status 200`.
2. `sec-websocket-protocol` / `sec-websocket-extensions` / `origin` / `user-agent` are forwarded upstream.
3. Returns `:status 502` when the upstream is unreachable.
4. Returns the upstream's non-101 status (e.g. 404) verbatim.
5. `opts.path` overrides the h2 `:path` header.
6. Self-loop tunnels back to the same h2 server over h1.1 and exchanges a greeting frame.

All 303 existing tests still pass. Typecheck + lint + fmt all clean.

## API surface

```ts
export interface ProxyH2UpgradeOptions {
  headers?: Record<string, string>;
  ssl?: Record<string, unknown>;
  secure?: boolean;       // verify upstream TLS (default true)
  timeout?: number;       // ms to wait for upstream 101 (default 15_000)
  path?: string;          // override :path
}

export function proxyH2Upgrade(
  addr: string | ProxyAddr,
  stream: ServerHttp2Stream,
  headers: IncomingHttpHeaders,
  opts?: ProxyH2UpgradeOptions,
): Promise<void>;

export function proxyH2UpgradeSelfLoop(
  h2Server: { address(): { port: number } | string | null },
  stream: ServerHttp2Stream,
  headers: IncomingHttpHeaders,
  opts?: ProxyH2UpgradeOptions,
): Promise<void>;
```

## Test plan
- [x] `pnpm test` — 303/305 (1 skipped, 1 todo, both pre-existing)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (oxlint + oxfmt)
- [x] `pnpm build` produces `dist/index.{mjs,d.mts}` with both new exports