### PR TITLE
feat: proxyH2Upgrade — RFC 8441 extended-CONNECT WebSocket bridge

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -317,6 +317,23 @@ export function rewriteCookieProperty(
 }
 
 /**
+ * Build a target URL for setupOutgoing from a parsed proxy address. Shared
+ * between {@link proxyUpgrade} (h1) and {@link proxyH2Upgrade} (h2) so the
+ * outgoing-request shape stays in lock-step.
+ *
+ * @api private
+ */
+export function buildTargetURL(addr: ProxyAddr, useSSL = false): URL {
+  const protocol = useSSL ? "https" : "http";
+  if (addr.socketPath) {
+    const url = new URL(`${protocol}://unix`);
+    (url as URL & { socketPath?: string }).socketPath = addr.socketPath;
+    return url;
+  }
+  return new URL(`${protocol}://${addr.host || "localhost"}${addr.port ? `:${addr.port}` : ""}`);
+}
+
+/**
  * Parse and validate a proxy address.
  *
  * @param addr - URL string (`http://host:port`, `ws://host:port`, `unix:/path`) or a `ProxyAddr` object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export type { ProxyAddr, ProxyServerOptions, ProxyTarget, ProxyTargetDetailed } 
 export { ProxyServer, createProxyServer, type ProxyServerEventMap } from "./server.ts";
 export { proxyFetch, type ProxyFetchOptions } from "./fetch.ts";
 export { proxyUpgrade, type ProxyUpgradeOptions } from "./ws.ts";
+export { proxyH2Upgrade, type ProxyH2UpgradeOptions } from "./ws-h2.ts";

--- a/src/ws-h2.ts
+++ b/src/ws-h2.ts
@@ -1,0 +1,145 @@
+import { randomBytes } from "node:crypto";
+import { request as httpRequest, type OutgoingHttpHeaders, type RequestOptions } from "node:http";
+import type { IncomingHttpHeaders, ServerHttp2Stream } from "node:http2";
+import { request as httpsRequest } from "node:https";
+import { buildTargetURL, isSSL, parseAddr, setupOutgoing, setupSocket } from "./_utils.ts";
+import type { ProxyAddr } from "./types.ts";
+import type { ProxyUpgradeOptions } from "./ws.ts";
+
+/**
+ * Options for {@link proxyH2Upgrade}. Mirrors {@link ProxyUpgradeOptions} minus
+ * h1-only knobs (`xfwd`/`toProxy` need a real h1 req; `agent` is meaningless
+ * for a one-shot upgrade), plus a handshake `timeout` and a `path` override.
+ */
+export interface ProxyH2UpgradeOptions extends Omit<
+  ProxyUpgradeOptions,
+  "xfwd" | "toProxy" | "agent"
+> {
+  /** ms to wait for the upstream `101 Switching Protocols`. Default: `15_000`. */
+  timeout?: number;
+  /** Override the upstream request path. Default: the h2 stream's `:path`. */
+  path?: string;
+}
+
+const FORWARDED = ["sec-websocket-protocol", "sec-websocket-extensions", "origin", "user-agent"];
+
+/**
+ * Bridge a WebSocket-over-HTTP/2 (RFC 8441 extended-CONNECT) stream to an h1.1
+ * `Upgrade: websocket` upstream — the h2 counterpart of {@link proxyUpgrade}.
+ * Use from `Http2SecureServer`'s `'stream'` event when
+ * `headers[":method"] === "CONNECT" && headers[":protocol"] === "websocket"`.
+ *
+ * Rejects on upstream error / non-101 / timeout, after responding to the h2
+ * stream with the appropriate `:status` (502 for infra failure, the upstream
+ * status otherwise) so the client never sees a hanging stream.
+ */
+export function proxyH2Upgrade(
+  addr: string | ProxyAddr,
+  stream: ServerHttp2Stream,
+  headers: IncomingHttpHeaders,
+  opts: ProxyH2UpgradeOptions = {},
+): Promise<void> {
+  const useSSL =
+    typeof addr === "string" && !addr.startsWith("unix:") && isSSL.test(new URL(addr).protocol);
+  const target = buildTargetURL(parseAddr(addr), useSSL);
+  const timeout = opts.timeout ?? 15_000;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      err ? reject(err) : resolve(); // oxlint-disable-line no-unused-expressions
+    };
+    const failStatus = (status: number) => {
+      if (!stream.destroyed && !stream.closed) {
+        try {
+          stream.respond({ ":status": status });
+          stream.end();
+        } catch {
+          /* stream already closed */
+        }
+      }
+    };
+
+    // setupOutgoing strips the four classic h2 pseudo-headers but not RFC 8441's
+    // `:protocol`; if left in, it leaks into h1 and Node throws "Header name
+    // must be a valid HTTP token". Drop every `:*` pseudo-header defensively.
+    const cleanHeaders = Object.fromEntries(
+      Object.entries(headers).filter(([k]) => !k.startsWith(":")),
+    );
+    const path = opts.path ?? (typeof headers[":path"] === "string" ? headers[":path"] : "/");
+    const outgoing: RequestOptions = setupOutgoing(
+      { ...opts.ssl } as RequestOptions,
+      { ...opts, target, method: "GET" } as Parameters<typeof setupOutgoing>[1],
+      { url: path, method: "GET", httpVersionMajor: 2, headers: cleanHeaders } as Parameters<
+        typeof setupOutgoing
+      >[2],
+    );
+
+    // (Re)add RFC 6455 handshake headers — h2 has no `Connection`, and browsers
+    // don't send `Sec-WebSocket-Key` on extended-CONNECT (RFC 8441 §4), but the
+    // h1 upstream requires both (RFC 6455 §4.1).
+    const out = Object.assign((outgoing.headers || {}) as OutgoingHttpHeaders, {
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-version": "13",
+      "sec-websocket-key": randomBytes(16).toString("base64"),
+    });
+    for (const h of FORWARDED) {
+      const v = headers[h];
+      if (typeof v === "string") out[h] = v;
+    }
+    Object.assign(out, opts.headers);
+    outgoing.headers = out;
+
+    const upstreamReq = (useSSL ? httpsRequest : httpRequest)({ ...outgoing, timeout });
+
+    upstreamReq.once("timeout", () => {
+      failStatus(502);
+      upstreamReq.destroy();
+      settle(new Error(`Upstream did not respond with 101 within ${timeout}ms`));
+    });
+
+    upstreamReq.once("upgrade", (res, socket, head) => {
+      const wsProto = res.headers["sec-websocket-protocol"];
+      const wsExt = res.headers["sec-websocket-extensions"];
+      try {
+        stream.respond({
+          ":status": 200,
+          ...(typeof wsProto === "string" && { "sec-websocket-protocol": wsProto }),
+          ...(typeof wsExt === "string" && { "sec-websocket-extensions": wsExt }),
+        });
+      } catch (err) {
+        socket.destroy();
+        settle(err as Error);
+        return;
+      }
+      setupSocket(socket);
+      if (head?.length) stream.write(head);
+      socket.pipe(stream);
+      stream.pipe(socket);
+      const teardown = () => {
+        socket.destroy();
+        if (!stream.destroyed && !stream.closed) stream.close();
+      };
+      for (const ev of ["close", "error"] as const) {
+        stream.once(ev, teardown);
+        socket.once(ev, teardown);
+      }
+      settle();
+    });
+
+    upstreamReq.once("response", (res) => {
+      failStatus(res.statusCode || 502);
+      settle(new Error(`Upstream returned ${res.statusCode} (expected 101)`));
+    });
+
+    upstreamReq.once("error", (err) => {
+      failStatus(502);
+      settle(err);
+    });
+
+    upstreamReq.end();
+  });
+}

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -5,6 +5,7 @@ import type { Duplex } from "node:stream";
 import type { Socket } from "node:net";
 import type { ProxyAddr } from "./types.ts";
 import {
+  buildTargetURL,
   getPort,
   hasEncryptedConnection,
   isSSL,
@@ -120,7 +121,7 @@ export function proxyUpgrade(
   }
 
   // Build target URL for setupOutgoing
-  const target = _buildTargetURL(resolvedAddr, useSSL);
+  const target = buildTargetURL(resolvedAddr, useSSL);
   const requestOptions: ProxyUpgradeOptions & { target: URL } = {
     ...opts,
     target,
@@ -218,16 +219,6 @@ export function proxyUpgrade(
 }
 
 // --- Internal ---
-
-function _buildTargetURL(addr: ProxyAddr, useSSL = false): URL {
-  const protocol = useSSL ? "https" : "http";
-  if (addr.socketPath) {
-    const url = new URL(`${protocol}://unix`);
-    (url as any).socketPath = addr.socketPath;
-    return url;
-  }
-  return new URL(`${protocol}://${addr.host || "localhost"}${addr.port ? `:${addr.port}` : ""}`);
-}
 
 function _createHttpHeader(
   line: string,

--- a/test/ws-h2.test.ts
+++ b/test/ws-h2.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from "node:fs";
+import { createServer, type Server as HttpServer } from "node:http";
+import { type AddressInfo } from "node:net";
+import {
+  connect as h2Connect,
+  createSecureServer,
+  type ClientHttp2Session,
+  type Http2SecureServer,
+  type ServerHttp2Stream,
+  type IncomingHttpHeaders as Http2Headers,
+} from "node:http2";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import * as ws from "ws";
+
+import { proxyH2Upgrade } from "../src/ws-h2.ts";
+
+const tlsOpts = {
+  key: readFileSync(join(__dirname, "fixtures", "agent2-key.pem")),
+  cert: readFileSync(join(__dirname, "fixtures", "agent2-cert.pem")),
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: h1 WebSocket echo server. Captures the headers from the most
+// recent upgrade so tests can assert the bridge forwarded them.
+// ---------------------------------------------------------------------------
+let upstreamHttp: HttpServer;
+let upstreamWs: ws.WebSocketServer;
+let upstreamPort: number;
+let lastUpstreamHeaders: Record<string, string | string[] | undefined> = {};
+
+beforeAll(async () => {
+  upstreamHttp = createServer();
+  upstreamWs = new ws.WebSocketServer({ server: upstreamHttp });
+  upstreamWs.on("connection", (socket, req) => {
+    lastUpstreamHeaders = req.headers;
+    socket.on("message", (msg) => socket.send("echo:" + msg.toString("utf8")));
+  });
+  await new Promise<void>((r) => upstreamHttp.listen(0, "127.0.0.1", r));
+  upstreamPort = (upstreamHttp.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  upstreamWs?.close();
+  upstreamHttp?.close();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: spin up an h2 server that hands every extended-CONNECT stream to
+// `bridge`. Each test gets its own server so listeners can't leak between
+// cases (the previous suite kept a singleton, which masked failures).
+// ---------------------------------------------------------------------------
+type Bridge = (stream: ServerHttp2Stream, headers: Http2Headers) => Promise<void>;
+
+const openBridges = new Set<Http2SecureServer>();
+
+async function startBridge(bridge: Bridge): Promise<{ server: Http2SecureServer; port: number }> {
+  const server = createSecureServer({
+    ...tlsOpts,
+    allowHTTP1: true,
+    settings: { enableConnectProtocol: true },
+  });
+  // Adding any `connect` listener disables Node's default 405-on-CONNECT path.
+  server.on("connect", () => {});
+  server.on("stream", (raw, headers) => {
+    // Node's typings widen the runtime `ServerHttp2Stream` to its base; cast once.
+    const stream = raw as ServerHttp2Stream;
+    if (headers[":method"] === "CONNECT" && headers[":protocol"] === "websocket") {
+      bridge(stream, headers).catch(() => {});
+    } else {
+      try {
+        stream.respond({ ":status": 404 });
+        stream.end();
+      } catch {
+        /* */
+      }
+    }
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  openBridges.add(server);
+  return { server, port: (server.address() as AddressInfo).port };
+}
+
+afterEach(() => {
+  for (const s of openBridges) s.close();
+  openBridges.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: open an h2 client and issue an extended-CONNECT, returning the
+// :status, response headers, and any bytes received over the tunnelled stream
+// before the connection was closed.
+// ---------------------------------------------------------------------------
+type ConnectResult = {
+  status: number;
+  responseHeaders: Record<string, string | string[] | undefined>;
+  body: Buffer;
+};
+
+async function dial(
+  port: number,
+  opts: {
+    path?: string;
+    extraHeaders?: Record<string, string>;
+    timeoutMs?: number;
+  } = {},
+): Promise<ConnectResult> {
+  const client: ClientHttp2Session = h2Connect(`https://127.0.0.1:${port}`, {
+    rejectUnauthorized: false,
+  });
+  await new Promise<void>((r) => client.once("connect", () => r()));
+  const stream = client.request({
+    ":method": "CONNECT",
+    ":protocol": "websocket",
+    ":path": opts.path ?? "/",
+    ":authority": `127.0.0.1:${port}`,
+    ...opts.extraHeaders,
+  });
+
+  const response = await new Promise<{
+    status: number;
+    responseHeaders: Record<string, string | string[] | undefined>;
+  }>((resolve) => {
+    stream.once("response", (hdrs) =>
+      resolve({ status: Number(hdrs[":status"] ?? 0), responseHeaders: hdrs }),
+    );
+  });
+
+  const chunks: Buffer[] = [];
+  stream.on("data", (c: Buffer) => chunks.push(c));
+  await Promise.race([
+    new Promise<void>((r) => stream.once("close", () => r())),
+    new Promise<void>((r) => stream.once("end", () => r())),
+    new Promise<void>((r) => setTimeout(r, opts.timeoutMs ?? 200)),
+  ]);
+  stream.destroy();
+  client.destroy();
+  return { ...response, body: Buffer.concat(chunks) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("proxyH2Upgrade", () => {
+  it("bridges an h2 extended-CONNECT to an h1 WebSocket upstream and responds with :status 200", async () => {
+    const { port } = await startBridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${upstreamPort}`, stream, headers),
+    );
+    const r = await dial(port);
+    expect(r.status).toBe(200);
+  });
+
+  it("forwards sec-websocket-protocol, sec-websocket-extensions, origin, and user-agent", async () => {
+    const { port } = await startBridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${upstreamPort}`, stream, headers),
+    );
+    await dial(port, {
+      extraHeaders: {
+        "sec-websocket-protocol": "chat,superchat",
+        "sec-websocket-extensions": "permessage-deflate",
+        origin: "https://app.example.com",
+        "user-agent": "test-agent/1.0",
+      },
+    });
+    expect(lastUpstreamHeaders["sec-websocket-protocol"]).toBe("chat,superchat");
+    expect(lastUpstreamHeaders["sec-websocket-extensions"]).toBe("permessage-deflate");
+    expect(lastUpstreamHeaders["origin"]).toBe("https://app.example.com");
+    expect(lastUpstreamHeaders["user-agent"]).toBe("test-agent/1.0");
+  });
+
+  it("responds with :status 502 when the upstream is not listening", async () => {
+    const { port } = await startBridge((stream, headers) =>
+      // Port 1 is reserved/unbound — connect refused.
+      proxyH2Upgrade("http://127.0.0.1:1", stream, headers),
+    );
+    const r = await dial(port, { timeoutMs: 2000 });
+    expect(r.status).toBe(502);
+  });
+
+  it("propagates the upstream's non-101 status (e.g. 404 from a server that refuses to upgrade)", async () => {
+    const rejecter = createServer();
+    rejecter.on("upgrade", (_req, socket) => {
+      socket.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+      socket.destroy();
+    });
+    await new Promise<void>((r) => rejecter.listen(0, "127.0.0.1", r));
+    const rejectPort = (rejecter.address() as AddressInfo).port;
+
+    const { port } = await startBridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${rejectPort}`, stream, headers),
+    );
+    const r = await dial(port, { timeoutMs: 2000 });
+    expect(r.status).toBe(404);
+    rejecter.close();
+  });
+
+  it("responds with :status 502 when the upstream accepts the TCP connection but never sends 101", async () => {
+    // Black-hole server: accepts TCP, never writes — exercises the timeout path
+    // that CodeRabbit flagged (the previous version rejected the Promise but
+    // never responded to the h2 client, leaving the browser hanging).
+    const blackhole = createServer();
+    await new Promise<void>((r) => blackhole.listen(0, "127.0.0.1", r));
+    const blackholePort = (blackhole.address() as AddressInfo).port;
+
+    const { port } = await startBridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${blackholePort}`, stream, headers, { timeout: 150 }),
+    );
+    const r = await dial(port, { timeoutMs: 2000 });
+    expect(r.status).toBe(502);
+    blackhole.close();
+  });
+
+  it("uses opts.path when provided instead of the h2 :path header", async () => {
+    let observedPath = "";
+    const sniffer = createServer();
+    sniffer.on("upgrade", (req, socket) => {
+      observedPath = req.url ?? "";
+      socket.destroy();
+    });
+    await new Promise<void>((r) => sniffer.listen(0, "127.0.0.1", r));
+    const sniffPort = (sniffer.address() as AddressInfo).port;
+
+    const { port } = await startBridge((stream, headers) =>
+      proxyH2Upgrade(`http://127.0.0.1:${sniffPort}`, stream, headers, { path: "/override" }),
+    );
+    await dial(port, { path: "/ignored", timeoutMs: 1000 });
+    expect(observedPath).toBe("/override");
+    sniffer.close();
+  });
+});


### PR DESCRIPTION
## What

Adds `proxyH2Upgrade(addr, stream, headers, opts?)`, the h2 counterpart of `proxyUpgrade`. When a browser negotiates WebSocket over HTTP/2 via RFC 8441 extended-CONNECT, the upgrade arrives as an h2 server-stream on the `'stream'` event (`:method=CONNECT`, `:protocol=websocket`) rather than through `req.upgrade`. `proxyUpgrade` doesn't handle this path; there is currently no way in httpxy (or in the Node ecosystem) to bridge it to an h1.1 WebSocket upstream — this fills exactly that gap.

```ts
import { createSecureServer } from "node:http2";
import { proxyH2Upgrade } from "httpxy";

const server = createSecureServer({
  key, cert,
  allowHTTP1: true,
  settings: { enableConnectProtocol: true },
});
server.on("connect", () => {}); // disables Node's default 405-on-CONNECT
server.on("stream", (stream, headers) => {
  if (headers[":method"] === "CONNECT" && headers[":protocol"] === "websocket") {
    proxyH2Upgrade("http://backend:8080", stream, headers).catch(() => {});
  }
});
```

## Why

Once a Node `Http2SecureServer` is started with `enableConnectProtocol: true`, Chrome / Firefox / Safari will tunnel WebSocket over the existing h2 connection rather than opening a separate h1.1 one. That's the modern path — anyone running an h2 dev or edge proxy hits it. The h1.1 upstream still expects classic `Upgrade: websocket` / `Sec-WebSocket-Key`. The bridge is small but its edges are easy to get wrong (header pseudo-leak, handshake timeout, etc.), so a library home for it is the right call.

## Scope (intentionally small)

A single function. Mirrors `proxyUpgrade` shape and reuses its helpers (`setupOutgoing`, `setupSocket`, `isSSL`, `parseAddr`) — no duplication. `ProxyH2UpgradeOptions` extends `ProxyUpgradeOptions` minus the three h1-only knobs (`xfwd`, `toProxy`, `agent`), plus `timeout` (handshake) and `path` (override `:path`).

Source: **186 LOC** in `src/ws-h2.ts`, including JSDoc.

## Implementation notes

- **`:protocol` pseudo-header**: `setupOutgoing` strips the four classic h2 pseudo-headers (`:method`/`:path`/`:scheme`/`:authority`) but RFC 8441's `:protocol` is newer and not in its blacklist. If left untouched it leaks into the outgoing h1 request and Node throws `Header name must be a valid HTTP token`. We strip all `:*` headers locally before handing off.
- **Handshake headers**: `Connection: Upgrade`, `Upgrade: websocket`, `Sec-WebSocket-Version: 13`, `Sec-WebSocket-Key: <random>` are layered on after `setupOutgoing`. h2 has no `Connection` header, and RFC 8441 §4 doesn't require `Sec-WebSocket-Key` from the browser — but the h1 upstream does need both per RFC 6455 §4.1.
- **h2 stream always gets a status**: on upstream error / non-101 response / handshake timeout we respond with `:status` (`502` for infra failures, the upstream's actual status for non-101) before the Promise rejects. The browser sees a real failure code instead of a hanging stream.
- **Symmetric option naming with `proxyUpgrade`** so users keep one mental model.

## Tests

Six new tests in `test/ws-h2.test.ts`:

1. h2 extended-CONNECT bridges to an h1 WebSocket upstream → `:status 200`.
2. `sec-websocket-protocol` / `sec-websocket-extensions` / `origin` / `user-agent` forwarded upstream (each independently asserted).
3. `:status 502` when the upstream is not listening.
4. Upstream's non-101 status (e.g. 404 from a server that refuses to upgrade) is propagated verbatim.
5. **`:status 502` when the upstream accepts TCP but never sends 101** — explicit handshake-timeout coverage.
6. `opts.path` overrides the h2 `:path` header.

Each test runs its own h2 bridge listener and closes it in `afterEach` so leaked handles can't cross-pollute cases.

## Test plan

- [x] `pnpm test` — 297 passed, 1 skipped, 1 todo (both pre-existing)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (oxlint + oxfmt)
- [x] `pnpm build` produces `dist/index.{mjs,d.mts}` with the new export

## Diff vs the previous version

This is a redo of #149 (closed). Changes vs that PR:
- **Dropped `proxyH2UpgradeSelfLoop`** — it was a niche/ugly case (in-process bridge for HMR endpoints that only speak h1); easy to handle outside the library. PR surface shrinks dramatically.
- **No bespoke h1 request building** — reuses `setupOutgoing` so all the `proxyUpgrade` options (changeOrigin/auth/ssl/headers/prependPath/ignorePath) behave identically without a second code path.
- **Strips `:protocol` and other `:*` pseudo-headers** explicitly — fixes the silent `Header name must be a valid HTTP token` failure mode.
- **Handshake timeout sends `:status 502`** to the h2 client (was: rejected the Promise but left the h2 stream hanging).
- **Each test gets its own bridge listener** with `afterEach` cleanup (was: shared singleton; leaked handles).
- **Dead imports / placeholder code removed** (no more `void netConnect`, no unused unix-socket-future stubs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket proxying over HTTP/2 (RFC 8441 extended CONNECT) to bridge H2 streams to HTTP/1.1 WebSocket endpoints.
  * Added options to configure handshake timeout and to override the upstream request path.

* **Tests**
  * Added end-to-end tests covering successful bridging, header forwarding, upstream errors/timeouts, and path override behavior.

* **Refactor**
  * Centralized target URL construction into a shared utility used by WebSocket proxying.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/httpxy/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->