### PR TITLE
types: declare `pathname` on ProxyTargetDetailed

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface ProxyTargetDetailed {
   port?: number | string;
   protocol?: string;
   hostname?: string;
+  pathname?: string;
   socketPath?: string;
   key?: string;
   passphrase?: string;


### PR DESCRIPTION
`setupOutgoing` already reads `target.pathname` for `ProxyTargetDetailed` targets — it just uses a `(target as URL)` cast in [`_utils.ts:156`](https://github.com/unjs/httpxy/blob/main/src/_utils.ts#L156) to silence the type error. Declaring the field on the interface so consumers passing a plain object can set it directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded proxy target details to optionally include a pathname, allowing more flexible request routing and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->