### PR TITLE
test: add regression test to ensure url embed preservation

### DIFF
--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -455,6 +455,20 @@ describe("lib/http-proxy/common.js", () => {
       expect(outgoing.path).to.eql("/" + google);
     });
 
+    // Ported from https://github.com/http-party/node-http-proxy/pull/1487
+    it("should preserve multiple http:// and https:// occurrences in the path", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        { target: URL.parse("http://localhost/")! },
+        stubIncomingMessage({
+          url: "/xyz/http://foobar.com/http://foobar.com/https://foobar.com",
+        }),
+      );
+
+      expect(outgoing.path).to.eql("/xyz/http://foobar.com/http://foobar.com/https://foobar.com");
+    });
+
     describe("when using ignorePath", () => {
       it("should ignore the path of the `req.url` passed in but use the target path", () => {
         const outgoing = createOutgoing();


### PR DESCRIPTION
A part of #2.

The https://github.com/http-party/node-http-proxy/pull/1487 bug doesn't exist in `httpxy`. This is because the join URL method we are using is from @h3js, which is a proper implementation.

Since `httpxy` embed/inline the `joinURL` implementation from @h3js, the PR ports the corresponding *regression test case* to ensure this case is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure generated outgoing paths keep embedded `http://` and `https://` segments intact within the incoming request path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->