### PR TITLE
fix: retain relative protocol in redirect location header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Returns Promise<Socket> (the upstream proxy socket)
 - Outgoing pass order is fixed: `removeChunked -> setConnection -> setRedirectHostRewrite -> writeHeaders -> writeStatusCode`.
 - Redirect rewrite applies on `201`, `301`, `302`, `303`, `307`, `308` only, and only when `Location` host matches `target.host`.
 - `hostRewrite` takes precedence over `autoRewrite`; `protocolRewrite` composes with either.
-- Protocol-relative `Location` values (`//host/path`) are preserved as protocol-relative after rewriting (WHATWG `URL` would otherwise absolutize them with the target protocol). Consequently `protocolRewrite` is a no-op for protocol-relative locations — the client resolves the scheme itself. Ported from node-http-proxy#1298.
+- Protocol-relative `Location` values (`//host/path`) stay protocol-relative when only the host is rewritten (`hostRewrite`/`autoRewrite`), so the client resolves the scheme itself (WHATWG `URL` would otherwise absolutize them with the target protocol). An explicit `protocolRewrite` opts into a concrete scheme and wins, absolutizing the value (e.g. `//host` → `https://host/`). The protocol-relative preservation is ported from node-http-proxy#1298; the `protocolRewrite`-wins interaction is httpxy-specific.
 - Cookie rewriting supports string or mapping config (including wildcard `"*"` and empty string for removal).
 - `preserveHeaderKeyCase` uses `rawHeaders` when available.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Returns Promise<Socket> (the upstream proxy socket)
 - Outgoing pass order is fixed: `removeChunked -> setConnection -> setRedirectHostRewrite -> writeHeaders -> writeStatusCode`.
 - Redirect rewrite applies on `201`, `301`, `302`, `303`, `307`, `308` only, and only when `Location` host matches `target.host`.
 - `hostRewrite` takes precedence over `autoRewrite`; `protocolRewrite` composes with either.
+- Protocol-relative `Location` values (`//host/path`) are preserved as protocol-relative after rewriting (WHATWG `URL` would otherwise absolutize them with the target protocol). Consequently `protocolRewrite` is a no-op for protocol-relative locations — the client resolves the scheme itself. Ported from node-http-proxy#1298.
 - Cookie rewriting supports string or mapping config (including wildcard `"*"` and empty string for removal).
 - `preserveHeaderKeyCase` uses `rawHeaders` when available.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ server.listen(3000, () => {
 | `buffer`                | `stream.Stream`                        | —          | Stream to use as request body instead of the incoming request               |
 
 > [!NOTE]
-> Redirect rewriting (`hostRewrite`, `autoRewrite`, `protocolRewrite`) only applies when the `Location` header host matches the target host, so cross-origin redirects are never altered. A protocol-relative `Location` (`//host/path`) is kept protocol-relative after rewriting — the client resolves it against its own scheme — which means `protocolRewrite` has no effect on such values.
+> Redirect rewriting (`hostRewrite`, `autoRewrite`, `protocolRewrite`) only applies when the `Location` header host matches the target host, so cross-origin redirects are never altered. A protocol-relative `Location` (`//host/path`) is kept protocol-relative when only the host is rewritten (`hostRewrite`/`autoRewrite`), so the client resolves the scheme itself. Setting `protocolRewrite` explicitly opts into a concrete scheme and absolutizes such values (e.g. `//host/path` → `https://host/path`).
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ server.listen(3000, () => {
 | `followRedirects`       | `boolean \| number`                    | `false`    | Follow HTTP redirects from target. `true` = max 5 hops; number = custom max |
 | `buffer`                | `stream.Stream`                        | —          | Stream to use as request body instead of the incoming request               |
 
+> [!NOTE]
+> Redirect rewriting (`hostRewrite`, `autoRewrite`, `protocolRewrite`) only applies when the `Location` header host matches the target host, so cross-origin redirects are never altered. A protocol-relative `Location` (`//host/path`) is kept protocol-relative after rewriting — the client resolves it against its own scheme — which means `protocolRewrite` has no effect on such values.
+
 ## Events
 
 | Event        | Arguments                                | Description                                            |

--- a/src/middleware/web-outgoing.ts
+++ b/src/middleware/web-outgoing.ts
@@ -69,9 +69,7 @@ export const setRedirectHostRewrite = defineProxyOutgoingMiddleware(
         u.protocol = options.protocolRewrite;
       }
 
-      proxyRes.headers.location = isProtocolRelative
-        ? u.href.slice(u.protocol.length)
-        : u.href;
+      proxyRes.headers.location = isProtocolRelative ? u.href.slice(u.protocol.length) : u.href;
     }
   },
 );

--- a/src/middleware/web-outgoing.ts
+++ b/src/middleware/web-outgoing.ts
@@ -45,10 +45,13 @@ export const setRedirectHostRewrite = defineProxyOutgoingMiddleware(
       redirectRegex.test(String(proxyRes.statusCode))
     ) {
       const target = _toURL(options.target!);
-      // Protocol-relative URLs (RFC 3986 §4.2 network-path reference) must stay
-      // protocol-relative after rewriting; WHATWG URL serialization would
-      // otherwise absolutize them with the target's protocol.
-      const isProtocolRelative = proxyRes.headers.location.startsWith("//");
+      // Protocol-relative URLs (RFC 3986 §4.2 network-path reference) let the
+      // client keep resolving the scheme itself, so preserve that form when only
+      // the host is rewritten (WHATWG URL would otherwise absolutize them with
+      // the target's protocol). An explicit `protocolRewrite` opts into a
+      // concrete scheme and wins, absolutizing the URL to that protocol.
+      const keepProtocolRelative =
+        proxyRes.headers.location.startsWith("//") && !options.protocolRewrite;
       const u = new URL(proxyRes.headers.location, target);
 
       // Make sure the redirected host matches the target host before rewriting
@@ -69,7 +72,7 @@ export const setRedirectHostRewrite = defineProxyOutgoingMiddleware(
         u.protocol = options.protocolRewrite;
       }
 
-      proxyRes.headers.location = isProtocolRelative ? u.href.slice(u.protocol.length) : u.href;
+      proxyRes.headers.location = keepProtocolRelative ? u.href.slice(u.protocol.length) : u.href;
     }
   },
 );

--- a/src/middleware/web-outgoing.ts
+++ b/src/middleware/web-outgoing.ts
@@ -45,6 +45,10 @@ export const setRedirectHostRewrite = defineProxyOutgoingMiddleware(
       redirectRegex.test(String(proxyRes.statusCode))
     ) {
       const target = _toURL(options.target!);
+      // Protocol-relative URLs (RFC 3986 §4.2 network-path reference) must stay
+      // protocol-relative after rewriting; WHATWG URL serialization would
+      // otherwise absolutize them with the target's protocol.
+      const isProtocolRelative = proxyRes.headers.location.startsWith("//");
       const u = new URL(proxyRes.headers.location, target);
 
       // Make sure the redirected host matches the target host before rewriting
@@ -65,7 +69,9 @@ export const setRedirectHostRewrite = defineProxyOutgoingMiddleware(
         u.protocol = options.protocolRewrite;
       }
 
-      proxyRes.headers.location = u.toString();
+      proxyRes.headers.location = isProtocolRelative
+        ? u.href.slice(u.protocol.length)
+        : u.href;
     }
   },
 );

--- a/test/middleware/web-outgoing.test.ts
+++ b/test/middleware/web-outgoing.test.ts
@@ -123,6 +123,18 @@ describe("middleware:web-outgoing", () => {
         );
         expect(ctx.proxyRes.headers.location).to.eql("http://ext-manual.com/redirect/here?foo=bar");
       });
+
+      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
+      it("handles protocol relative URLs", () => {
+        ctx.proxyRes.headers.location = "//backend.com";
+        webOutgoing.setRedirectHostRewrite(
+          ctx.req,
+          stubServerResponse(),
+          ctx.proxyRes,
+          ctx.options,
+        );
+        expect(ctx.proxyRes.headers.location).to.eql("//ext-manual.com/");
+      });
     });
 
     describe("rewrites location host with autoRewrite", () => {
@@ -270,6 +282,18 @@ describe("middleware:web-outgoing", () => {
         expect(ctx.proxyRes.headers.location).to.eql("http://backend.com/");
       });
 
+      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
+      it("not when protocol relative URL is used", () => {
+        ctx.proxyRes.headers.location = "//backend.com";
+        webOutgoing.setRedirectHostRewrite(
+          ctx.req,
+          stubServerResponse(),
+          ctx.proxyRes,
+          ctx.options,
+        );
+        expect(ctx.proxyRes.headers.location).to.eql("//backend.com/");
+      });
+
       it("works together with hostRewrite", () => {
         ctx.options.hostRewrite = "ext-manual.com";
         webOutgoing.setRedirectHostRewrite(
@@ -281,6 +305,19 @@ describe("middleware:web-outgoing", () => {
         expect(ctx.proxyRes.headers.location).to.eql("https://ext-manual.com/");
       });
 
+      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
+      it("not with hostRewrite when a protocol relative URL is used", () => {
+        ctx.options.hostRewrite = "ext-manual.com";
+        ctx.proxyRes.headers.location = "//backend.com";
+        webOutgoing.setRedirectHostRewrite(
+          ctx.req,
+          stubServerResponse(),
+          ctx.proxyRes,
+          ctx.options,
+        );
+        expect(ctx.proxyRes.headers.location).to.eql("//ext-manual.com/");
+      });
+
       it("works together with autoRewrite", () => {
         ctx.options.autoRewrite = true;
         webOutgoing.setRedirectHostRewrite(
@@ -290,6 +327,19 @@ describe("middleware:web-outgoing", () => {
           ctx.options,
         );
         expect(ctx.proxyRes.headers.location).to.eql("https://ext-auto.com/");
+      });
+
+      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
+      it("not with autoRewrite when a protocol relative URL is used", () => {
+        ctx.options.autoRewrite = true;
+        ctx.proxyRes.headers.location = "//backend.com/";
+        webOutgoing.setRedirectHostRewrite(
+          ctx.req,
+          stubServerResponse(),
+          ctx.proxyRes,
+          ctx.options,
+        );
+        expect(ctx.proxyRes.headers.location).to.eql("//ext-auto.com/");
       });
     });
   });

--- a/test/middleware/web-outgoing.test.ts
+++ b/test/middleware/web-outgoing.test.ts
@@ -282,6 +282,19 @@ describe("middleware:web-outgoing", () => {
         expect(ctx.proxyRes.headers.location).to.eql("http://backend.com/");
       });
 
+      // protocolRewrite is a no-op for protocol-relative URLs: the value stays
+      // protocol-relative so the client resolves the scheme itself.
+      it("is a no-op when a protocol relative URL is used", () => {
+        ctx.proxyRes.headers.location = "//backend.com";
+        webOutgoing.setRedirectHostRewrite(
+          ctx.req,
+          stubServerResponse(),
+          ctx.proxyRes,
+          ctx.options,
+        );
+        expect(ctx.proxyRes.headers.location).to.eql("//backend.com/");
+      });
+
       // Ported from https://github.com/http-party/node-http-proxy/pull/1298
       it("not when protocol relative URL is used", () => {
         ctx.proxyRes.headers.location = "//backend.com";

--- a/test/middleware/web-outgoing.test.ts
+++ b/test/middleware/web-outgoing.test.ts
@@ -282,9 +282,9 @@ describe("middleware:web-outgoing", () => {
         expect(ctx.proxyRes.headers.location).to.eql("http://backend.com/");
       });
 
-      // protocolRewrite is a no-op for protocol-relative URLs: the value stays
-      // protocol-relative so the client resolves the scheme itself.
-      it("is a no-op when a protocol relative URL is used", () => {
+      // An explicit protocolRewrite opts into a concrete scheme, so it wins over
+      // protocol-relative preservation: the URL is absolutized to that scheme.
+      it("absolutizes a protocol relative URL to the rewritten protocol", () => {
         ctx.proxyRes.headers.location = "//backend.com";
         webOutgoing.setRedirectHostRewrite(
           ctx.req,
@@ -292,19 +292,7 @@ describe("middleware:web-outgoing", () => {
           ctx.proxyRes,
           ctx.options,
         );
-        expect(ctx.proxyRes.headers.location).to.eql("//backend.com/");
-      });
-
-      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
-      it("not when protocol relative URL is used", () => {
-        ctx.proxyRes.headers.location = "//backend.com";
-        webOutgoing.setRedirectHostRewrite(
-          ctx.req,
-          stubServerResponse(),
-          ctx.proxyRes,
-          ctx.options,
-        );
-        expect(ctx.proxyRes.headers.location).to.eql("//backend.com/");
+        expect(ctx.proxyRes.headers.location).to.eql("https://backend.com/");
       });
 
       it("works together with hostRewrite", () => {
@@ -318,8 +306,8 @@ describe("middleware:web-outgoing", () => {
         expect(ctx.proxyRes.headers.location).to.eql("https://ext-manual.com/");
       });
 
-      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
-      it("not with hostRewrite when a protocol relative URL is used", () => {
+      // protocolRewrite wins even when combined with hostRewrite.
+      it("absolutizes a protocol relative URL together with hostRewrite", () => {
         ctx.options.hostRewrite = "ext-manual.com";
         ctx.proxyRes.headers.location = "//backend.com";
         webOutgoing.setRedirectHostRewrite(
@@ -328,7 +316,7 @@ describe("middleware:web-outgoing", () => {
           ctx.proxyRes,
           ctx.options,
         );
-        expect(ctx.proxyRes.headers.location).to.eql("//ext-manual.com/");
+        expect(ctx.proxyRes.headers.location).to.eql("https://ext-manual.com/");
       });
 
       it("works together with autoRewrite", () => {
@@ -342,8 +330,8 @@ describe("middleware:web-outgoing", () => {
         expect(ctx.proxyRes.headers.location).to.eql("https://ext-auto.com/");
       });
 
-      // Ported from https://github.com/http-party/node-http-proxy/pull/1298
-      it("not with autoRewrite when a protocol relative URL is used", () => {
+      // protocolRewrite wins even when combined with autoRewrite.
+      it("absolutizes a protocol relative URL together with autoRewrite", () => {
         ctx.options.autoRewrite = true;
         ctx.proxyRes.headers.location = "//backend.com/";
         webOutgoing.setRedirectHostRewrite(
@@ -352,7 +340,7 @@ describe("middleware:web-outgoing", () => {
           ctx.proxyRes,
           ctx.options,
         );
-        expect(ctx.proxyRes.headers.location).to.eql("//ext-auto.com/");
+        expect(ctx.proxyRes.headers.location).to.eql("https://ext-auto.com/");
       });
     });
   });


### PR DESCRIPTION
Part of #2.

The original bug https://github.com/http-party/node-http-proxy/pull/1298 does not exist in `httpxy`. They use Node.js legacy URL parsing, but we already use WHATWG URL. So, unlike `node-http-proxy`, we `httpxy` do not break anything here.

However, the test case exposes a different *nit*: because we are using WHATWG URL, after we serialize the destination (`u.toString()`), we produce `http://ext-manual.com/` instead of retaining the relative protocol `//ext-manual.com/`.

The PR fixes this nit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect rewriting for protocol-relative `Location` headers (`//host/path`) so they remain protocol-relative after applying rewrite options.
  * Ensured protocol rewriting has no effect on protocol-relative redirects, and redirects are only rewritten when appropriate.
* **Tests**
  * Added coverage for protocol-relative redirect behavior under different rewrite configuration combinations.
* **Documentation**
  * Updated guidance in the README and agent documentation to clarify protocol-relative redirect semantics and cross-origin redirect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->