### PR TITLE
fix: force `connection: close` on chunked upstream requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Returns Promise<Socket> (the upstream proxy socket)
 ### HTTP middleware semantics
 
 - Incoming pass order is fixed: `deleteLength -> timeout -> XHeaders -> stream`.
-- `deleteLength` applies to both `DELETE` and `OPTIONS` without content length; it sets `content-length: 0` and removes `transfer-encoding`.
+- `deleteLength` applies to both `DELETE` and `OPTIONS`; it sets `content-length: 0` **only when the request carries neither `content-length` nor `transfer-encoding`**. It never strips `transfer-encoding` — a chunked request keeps its body and framing (request-smuggling fix, GHSA-ggv3-7p47-pfv8).
 - `proxyReq` event is intentionally skipped when request has `expect` header (`100-continue` advisory coverage).
 - `selfHandleResponse: true` skips outgoing passes and auto-pipe; callers must finish the response in `proxyRes`.
 - `proxyTimeout` aborts upstream request and surfaces timeout errors (tested as `ECONNRESET`).
@@ -96,6 +96,12 @@ Returns Promise<Socket> (the upstream proxy socket)
 - `hostRewrite` takes precedence over `autoRewrite`; `protocolRewrite` composes with either.
 - Cookie rewriting supports string or mapping config (including wildcard `"*"` and empty string for removal).
 - `preserveHeaderKeyCase` uses `rawHeaders` when available.
+
+### Outgoing request / connection semantics (`setupOutgoing`, `src/_utils.ts`)
+
+- Defaults to shared keep-alive agents (`defaultAgents.http` / `.https`) for upstream connection reuse. WebSocket upgrades and HTTP/2 incoming requests use `agent: false` instead (agents conflict with the socket lifecycle). A caller-provided `agent` (including `false`) always wins.
+- When there is no agent (`agent: false`) and the request is not an upgrade, `connection: close` is forced (stock http-proxy behavior).
+- **Request-smuggling hardening (GHSA-ggv3-7p47-pfv8):** `connection: close` is additionally forced — _regardless of agent_ — whenever the outgoing request carries a `transfer-encoding` header, or its `Connection` header lists `transfer-encoding` as hop-by-hop. This prevents an upstream keep-alive socket from being reused after a chunked request, so a desync at a lenient upstream cannot poison a later user's response. It also closes the `Connection: upgrade` + chunked-body bypass. Genuine WebSocket upgrades (no `transfer-encoding`) keep their `Connection` header intact.
 
 ### URL/path handling invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ test/
 ├── http-proxy.test.ts             — Forward, target, WebSocket, socket.io, SSE, timeouts, error events
 ├── https-proxy.test.ts            — HTTPS targets, SSL certs, certificate validation
 ├── _utils.test.ts                 — setupOutgoing, setupSocket, path joining, auth, changeOrigin
+├── request-smuggling.test.ts      — End-to-end GHSA-ggv3-7p47-pfv8 reproduction (chunked payload hiding a smuggled request; asserts it never reaches a lenient upstream), ported from vercel/next.js
 ├── types.test-d.ts                — TypeScript type assertions (vitest typecheck)
 └── middleware/
     ├── web-incoming.test.ts       — deleteLength, timeout, XHeaders

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ Returns Promise<Socket> (the upstream proxy socket)
 - Defaults to shared keep-alive agents (`defaultAgents.http` / `.https`) for upstream connection reuse. WebSocket upgrades and HTTP/2 incoming requests use `agent: false` instead (agents conflict with the socket lifecycle). A caller-provided `agent` (including `false`) always wins.
 - When there is no agent (`agent: false`) and the request is not an upgrade, `connection: close` is forced (stock http-proxy behavior).
 - **Request-smuggling hardening (GHSA-ggv3-7p47-pfv8):** `connection: close` is additionally forced — _regardless of agent_ — whenever the outgoing request carries a `transfer-encoding` header, or its `Connection` header lists `transfer-encoding` as hop-by-hop. This prevents an upstream keep-alive socket from being reused after a chunked request, so a desync at a lenient upstream cannot poison a later user's response. It also closes the `Connection: upgrade` + chunked-body bypass. Genuine WebSocket upgrades (no `transfer-encoding`) keep their `Connection` header intact.
+- The hardening lives in the shared helper `forceConnectionCloseForTransferEncoding()` (`src/_utils.ts`) and is applied on **every** outgoing-request path, so no path can leak a reusable chunked socket:
+  - `setupOutgoing` — ProxyServer `web`/`ws` initial requests.
+  - `proxyFetch`'s `_sendRequest` — re-runs the helper on each recursion, covering both the initial request and every `followRedirects` 307/308 replay hop.
+  - `web-incoming`'s `followRedirects` 307/308 replay (`src/middleware/web-incoming.ts`) — this replay builds its `redirectReq` options by hand rather than via `setupOutgoing`, so it calls the helper directly on `redirectHeaders` before building the request options.
 
 ### URL/path handling invariants
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -5,6 +5,7 @@ import type { ProxyAddr, ProxyServerOptions, ProxyTarget, ProxyTargetDetailed } 
 import type { Http2ServerRequest } from "node:http2";
 
 const upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i;
+const transferEncodingConnectionToken = /(^|,)\s*transfer-encoding\s*($|,)/i;
 
 /**
  * Default keep-alive agents for connection reuse.
@@ -149,6 +150,28 @@ export function setupOutgoing(
     ) {
       outgoing.headers.connection = "close";
     }
+  }
+
+  // Request smuggling hardening (GHSA-ggv3-7p47-pfv8).
+  //
+  // A chunked (`transfer-encoding`) request is exactly where proxy<->upstream
+  // framing disagreements arise. If a desync ever occurs on a reused keep-alive
+  // socket, an attacker's leftover body bytes could be read as a pipelined next
+  // request and poison another user's response. Since httpxy reuses upstream
+  // sockets by default (keep-alive agents), force `connection: close` on any
+  // request that carries `transfer-encoding` — or that marks `transfer-encoding`
+  // as hop-by-hop via its `Connection` header — so the upstream socket is torn
+  // down after use and can never be reused. This is independent of the agent
+  // and also closes the `Connection: upgrade` + chunked-body bypass vector.
+  outgoing.headers = outgoing.headers || {};
+  const carriesTransferEncoding = Object.entries(outgoing.headers).some(
+    ([header, value]) => header.toLowerCase() === "transfer-encoding" && value !== undefined,
+  );
+  const connectionMarksTransferEncoding =
+    typeof outgoing.headers.connection === "string" &&
+    transferEncodingConnectionToken.test(outgoing.headers.connection);
+  if (carriesTransferEncoding || connectionMarksTransferEncoding) {
+    outgoing.headers.connection = "close";
   }
 
   // the final path is target path + relative path requested by user:

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -21,6 +21,40 @@ export const defaultAgents = {
 export const isSSL = /^https|wss/;
 
 /**
+ * Request-smuggling hardening (GHSA-ggv3-7p47-pfv8).
+ *
+ * A chunked (`transfer-encoding`) request is exactly where proxy<->upstream framing
+ * disagreements arise. If a desync ever occurs on a reused keep-alive socket, an
+ * attacker's leftover body bytes could be read as a pipelined next request and poison
+ * another user's response. Force `connection: close` on any request that carries
+ * `transfer-encoding` — or that marks `transfer-encoding` as hop-by-hop via its
+ * `Connection` header — so the upstream socket is torn down after use and can never be
+ * reused. This is independent of the agent and also closes the `Connection: upgrade` +
+ * chunked-body bypass vector.
+ *
+ * Shared by every outgoing-request path (`setupOutgoing`, `proxyFetch`) so keep-alive
+ * socket reuse after a chunked request is impossible regardless of how the request is
+ * built.
+ */
+export function forceConnectionCloseForTransferEncoding(
+  headers: Record<string, string | string[] | number | undefined>,
+): void {
+  let carriesTransferEncoding = false;
+  for (const key in headers) {
+    if (headers[key] !== undefined && key.toLowerCase() === "transfer-encoding") {
+      carriesTransferEncoding = true;
+      break;
+    }
+  }
+  const connection = headers.connection;
+  const connectionMarksTransferEncoding =
+    typeof connection === "string" && transferEncodingConnectionToken.test(connection);
+  if (carriesTransferEncoding || connectionMarksTransferEncoding) {
+    headers.connection = "close";
+  }
+}
+
+/**
  * Node.js HTTP/2 accepts pseudo headers and it may conflict
  * with request options.
  *
@@ -152,27 +186,11 @@ export function setupOutgoing(
     }
   }
 
-  // Request smuggling hardening (GHSA-ggv3-7p47-pfv8).
-  //
-  // A chunked (`transfer-encoding`) request is exactly where proxy<->upstream
-  // framing disagreements arise. If a desync ever occurs on a reused keep-alive
-  // socket, an attacker's leftover body bytes could be read as a pipelined next
-  // request and poison another user's response. Since httpxy reuses upstream
-  // sockets by default (keep-alive agents), force `connection: close` on any
-  // request that carries `transfer-encoding` — or that marks `transfer-encoding`
-  // as hop-by-hop via its `Connection` header — so the upstream socket is torn
-  // down after use and can never be reused. This is independent of the agent
-  // and also closes the `Connection: upgrade` + chunked-body bypass vector.
+  // Request smuggling hardening (GHSA-ggv3-7p47-pfv8): tear down the upstream
+  // socket after any chunked request so it can never be reused. See
+  // `forceConnectionCloseForTransferEncoding` for rationale.
   outgoing.headers = outgoing.headers || {};
-  const carriesTransferEncoding = Object.entries(outgoing.headers).some(
-    ([header, value]) => header.toLowerCase() === "transfer-encoding" && value !== undefined,
-  );
-  const connectionMarksTransferEncoding =
-    typeof outgoing.headers.connection === "string" &&
-    transferEncodingConnectionToken.test(outgoing.headers.connection);
-  if (carriesTransferEncoding || connectionMarksTransferEncoding) {
-    outgoing.headers.connection = "close";
-  }
+  forceConnectionCloseForTransferEncoding(outgoing.headers);
 
   // the final path is target path + relative path requested by user:
   const target = options[forward || "target"];

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -3,7 +3,13 @@ import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { Readable } from "node:stream";
 import type { ProxyAddr } from "./types.ts";
-import { defaultAgents, isSSL, joinURL, parseAddr } from "./_utils.ts";
+import {
+  defaultAgents,
+  forceConnectionCloseForTransferEncoding,
+  isSSL,
+  joinURL,
+  parseAddr,
+} from "./_utils.ts";
 
 /**
  * Options for {@link proxyFetch}.
@@ -289,6 +295,12 @@ function _sendRequest(
   body: Buffer | Readable | undefined,
   opts: _RequestOpts,
 ): Promise<IncomingMessage> {
+  // Request smuggling hardening (GHSA-ggv3-7p47-pfv8): proxyFetch defaults to a shared
+  // keep-alive agent, so a chunked request must force `connection: close` to prevent the
+  // upstream socket from being reused. Applied here — the single chokepoint for both the
+  // initial request and every redirect hop.
+  forceConnectionCloseForTransferEncoding(headers);
+
   return new Promise<IncomingMessage>((resolve, reject) => {
     const reqOpts: RequestOptions = {
       method,

--- a/src/middleware/web-incoming.ts
+++ b/src/middleware/web-incoming.ts
@@ -2,7 +2,13 @@ import type { ClientRequest, IncomingMessage, ServerResponse } from "node:http";
 import type { ProxyTargetDetailed } from "../types.ts";
 import nodeHTTP from "node:http";
 import nodeHTTPS from "node:https";
-import { getPort, hasEncryptedConnection, isSSL, setupOutgoing } from "../_utils.ts";
+import {
+  forceConnectionCloseForTransferEncoding,
+  getPort,
+  hasEncryptedConnection,
+  isSSL,
+  setupOutgoing,
+} from "../_utils.ts";
 import { webOutgoingMiddleware } from "./web-outgoing.ts";
 import { type ProxyMiddleware, defineProxyMiddleware } from "./_utils.ts";
 
@@ -214,6 +220,11 @@ export const stream = defineProxyMiddleware((req, res, options, server, head, ca
         delete redirectHeaders["content-type"];
         delete redirectHeaders["transfer-encoding"];
       }
+
+      // Request smuggling hardening (GHSA-ggv3-7p47-pfv8): this replay bypasses
+      // setupOutgoing, so force `connection: close` on a chunked 307/308 replay to
+      // stop a caller-supplied keep-alive agent from reusing the upstream socket.
+      forceConnectionCloseForTransferEncoding(redirectHeaders);
 
       const redirectOpts: nodeHTTP.RequestOptions = {
         hostname: location.hostname,

--- a/test/_utils.test.ts
+++ b/test/_utils.test.ts
@@ -211,6 +211,68 @@ describe("lib/http-proxy/common.js", () => {
       expect(outgoing.agent).to.eql(false);
     });
 
+    // Request smuggling hardening (GHSA-ggv3-7p47-pfv8): a request carrying
+    // `transfer-encoding` must not reuse an upstream keep-alive socket, so its
+    // outgoing `connection` header is forced to `close` regardless of agent.
+    it("should force connection: close on chunked (transfer-encoding) requests even with a keep-alive agent", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        { target: "http://localhost" },
+        stubIncomingMessage({
+          method: "OPTIONS",
+          url: "/",
+          headers: { "transfer-encoding": "chunked" },
+        }),
+      );
+      // Default keep-alive agent is still selected...
+      expect(outgoing.agent).to.eql(common.defaultAgents.http);
+      // ...but the socket must be torn down after this request.
+      expect(outgoing.headers!.connection).to.eql("close");
+      expect(outgoing.headers!["transfer-encoding"]).to.eql("chunked");
+    });
+
+    it("should force connection: close when Connection marks transfer-encoding as hop-by-hop", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        { target: "http://localhost" },
+        stubIncomingMessage({
+          url: "/",
+          headers: { connection: "keep-alive, transfer-encoding" },
+        }),
+      );
+      expect(outgoing.headers!.connection).to.eql("close");
+    });
+
+    it("should force connection: close on transfer-encoding even when Connection is upgrade (bypass vector)", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        { target: "http://localhost" },
+        stubIncomingMessage({
+          method: "OPTIONS",
+          url: "/",
+          headers: { connection: "upgrade", "transfer-encoding": "chunked" },
+        }),
+      );
+      expect(outgoing.headers!.connection).to.eql("close");
+    });
+
+    it("should not force connection: close on genuine websocket upgrades (no transfer-encoding)", () => {
+      const outgoing = createOutgoing();
+      common.setupOutgoing(
+        outgoing,
+        { target: "http://localhost" },
+        stubIncomingMessage({
+          url: "/",
+          headers: { connection: "keep-alive, upgrade", upgrade: "websocket" },
+        }),
+      );
+      // Upgrade requests must keep their Connection header intact.
+      expect(outgoing.headers!.connection).to.eql("keep-alive, upgrade");
+    });
+
     it("set the port according to the protocol", () => {
       const outgoing = createOutgoing();
       common.setupOutgoing(

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -482,6 +482,71 @@ describe("proxyFetch", () => {
     });
   });
 
+  describe("request smuggling hardening (GHSA-ggv3-7p47-pfv8)", () => {
+    it("forces connection: close on a chunked request over a keep-alive agent", async () => {
+      const { Agent } = await import("node:http");
+      const agent = new Agent({ keepAlive: true });
+      try {
+        const res = await proxyFetch(
+          { host: "127.0.0.1", port: tcpPort },
+          `http://localhost/headers`,
+          { headers: { "transfer-encoding": "chunked" } },
+          { agent },
+        );
+        const body = (await res.json()) as { headers: Record<string, string> };
+        expect(body.headers.connection).toBe("close");
+      } finally {
+        agent.destroy();
+      }
+    });
+
+    it("forces connection: close when Connection marks transfer-encoding hop-by-hop", async () => {
+      const res = await proxyFetch(
+        { host: "127.0.0.1", port: tcpPort },
+        `http://localhost/headers`,
+        { headers: { connection: "keep-alive, transfer-encoding" } },
+      );
+      const body = (await res.json()) as { headers: Record<string, string> };
+      expect(body.headers.connection).toBe("close");
+    });
+
+    it("forces connection: close on the 307 replay of a chunked request", async () => {
+      const { Agent } = await import("node:http");
+      const agent = new Agent({ keepAlive: true });
+      try {
+        const res = await proxyFetch(
+          { host: "127.0.0.1", port: tcpPort },
+          `http://localhost/redirect-307`,
+          { method: "POST", body: "chunked-body", headers: { "transfer-encoding": "chunked" } },
+          { agent, followRedirects: true },
+        );
+        // /redirect-307 → /echo; echo replies with the request body, and the
+        // replayed request must have been sent with connection: close.
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("chunked-body");
+      } finally {
+        agent.destroy();
+      }
+    });
+
+    it("leaves connection intact for a non-chunked request", async () => {
+      const { Agent } = await import("node:http");
+      const agent = new Agent({ keepAlive: true });
+      try {
+        const res = await proxyFetch(
+          { host: "127.0.0.1", port: tcpPort },
+          `http://localhost/headers`,
+          undefined,
+          { agent },
+        );
+        const body = (await res.json()) as { headers: Record<string, string> };
+        expect(body.headers.connection).not.toBe("close");
+      } finally {
+        agent.destroy();
+      }
+    });
+  });
+
   describe("body types", () => {
     it("sends ArrayBuffer body", async () => {
       const buf = new TextEncoder().encode("arraybuffer-body");

--- a/test/middleware/web-incoming.test.ts
+++ b/test/middleware/web-incoming.test.ts
@@ -960,6 +960,64 @@ describe("#followRedirects", () => {
       .end();
     await promise;
   });
+
+  // Regression: GHSA-ggv3-7p47-pfv8. The 307/308 replay bypasses setupOutgoing, so
+  // it must independently force `connection: close` on a chunked request — otherwise a
+  // caller-supplied keep-alive agent could reuse the upstream socket after a desync.
+  it("forces connection: close on the 307 replay of a chunked request", async () => {
+    const { resolve, promise } = Promise.withResolvers<void>();
+    const keepAliveAgent = new http.Agent({ keepAlive: true });
+
+    let replayConnection: string | undefined;
+    const source = http.createServer(function (req: any, res: any) {
+      if (new URL(req.url, "http://localhost").pathname === "/dest") {
+        replayConnection = req.headers.connection;
+        let body = "";
+        req.on("data", (chunk: Buffer) => (body += chunk));
+        req.on("end", () => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end(body);
+        });
+        return;
+      }
+      res.writeHead(307, { Location: "/dest" });
+      res.end();
+    });
+    const sourcePort = await listenOn(source);
+
+    const proxy = httpProxy.createProxyServer({
+      target: `http://127.0.0.1:${sourcePort}`,
+      followRedirects: true,
+      agent: keepAliveAgent,
+    });
+
+    const proxyServer = http.createServer((req, res) => proxy.web(req, res));
+    const proxyPort = await listenOn(proxyServer);
+
+    const proxyReq = http.request(
+      `http://127.0.0.1:${proxyPort}`,
+      // `connection: keep-alive` + no content-length → Node frames the body as
+      // `transfer-encoding: chunked`; without the fix the replay would inherit
+      // `connection: keep-alive` from the original request headers.
+      { method: "POST", headers: { connection: "keep-alive" } },
+      function (res) {
+        let body = "";
+        res.on("data", (chunk: Buffer) => (body += chunk));
+        res.on("end", () => {
+          source.close();
+          proxyServer.close();
+          keepAliveAgent.destroy();
+          expect(res.statusCode).to.eql(200);
+          expect(body).to.eql("chunk-body");
+          expect(replayConnection).to.eql("close");
+          resolve();
+        });
+      },
+    );
+    proxyReq.write("chunk-body");
+    proxyReq.end();
+    await promise;
+  });
 });
 
 // Regression: upstream http-party/node-http-proxy#1559

--- a/test/middleware/web-incoming.test.ts
+++ b/test/middleware/web-incoming.test.ts
@@ -1132,3 +1132,66 @@ describe("#chunked-body-smuggling", () => {
     await promise;
   });
 });
+
+// Request smuggling hardening (GHSA-ggv3-7p47-pfv8): even though the proxy no
+// longer creates a desync, a chunked request must not reuse an upstream
+// keep-alive socket. If a lenient upstream ever desynced, socket reuse is what
+// makes it exploitable (leftover bytes read as another user's request). The
+// proxy therefore sends `Connection: close` upstream for any chunked request,
+// so the socket is torn down after use even though httpxy defaults to
+// keep-alive agents.
+describe("#chunked-connection-teardown", () => {
+  it("should send `connection: close` upstream for a chunked request despite default keep-alive agents", async () => {
+    const net = await import("node:net");
+    const { resolve, reject, promise } = Promise.withResolvers<void>();
+
+    let upstreamConnection: string | undefined;
+    const source = http.createServer((req, res) => {
+      upstreamConnection = req.headers.connection as string | undefined;
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+      });
+    });
+    const sourcePort = await listenOn(source);
+
+    const proxy = httpProxy.createProxyServer({
+      target: `http://127.0.0.1:${sourcePort}`,
+    });
+    const proxyServer = http.createServer((req, res) => proxy.web(req, res));
+    const proxyPort = await listenOn(proxyServer);
+
+    const rawRequest =
+      "OPTIONS / HTTP/1.1\r\n" +
+      `Host: 127.0.0.1:${proxyPort}\r\n` +
+      "Connection: keep-alive\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "0\r\n" +
+      "\r\n";
+
+    const socket = net.connect(proxyPort, "127.0.0.1", () => socket.write(rawRequest));
+
+    const finish = (fn: () => void) => {
+      socket.destroy();
+      source.close();
+      proxyServer.close();
+      fn();
+    };
+
+    socket.once("data", () => {
+      setTimeout(() => {
+        try {
+          expect(upstreamConnection).to.eql("close");
+          finish(resolve);
+        } catch (error) {
+          finish(() => reject(error as Error));
+        }
+      }, 100);
+    });
+    socket.on("error", (error) => finish(() => reject(error)));
+
+    await promise;
+  });
+});

--- a/test/request-smuggling.test.ts
+++ b/test/request-smuggling.test.ts
@@ -1,0 +1,224 @@
+import http from "node:http";
+import net from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import * as httpProxy from "../src/index.ts";
+import { listenOn } from "./_utils.ts";
+
+// End-to-end request-smuggling coverage for GHSA-ggv3-7p47-pfv8, ported from the
+// upstream reproduction at
+// vercel/next.js/test/production/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
+//
+// A crafted request declares `Transfer-Encoding: chunked` and hides a second
+// `GET /secret` request inside its chunked body. If the proxy lets the upstream
+// keep-alive socket be reused after the chunked request, a lenient/desync-prone
+// upstream can interpret the leftover body bytes as a pipelined second request and
+// execute the smuggled `GET /secret`. The fix forces `Connection: close` on any
+// chunked outgoing request, so a close-delimited upstream processes exactly one
+// request per connection and the smuggled request is never executed.
+
+const SMUGGLED_MARKER = "GET /secret HTTP/1.1";
+
+/**
+ * A deliberately lenient upstream that models a desync-prone server: it reads the
+ * first request's head, then — only if the request was NOT close-delimited — scans
+ * the remaining bytes on the same connection for a pipelined request line. This is
+ * the amplifier the fix removes: with `Connection: close` the upstream stops after
+ * one request and the smuggled bytes are discarded; with keep-alive it "executes"
+ * the smuggled request.
+ */
+function createLenientUpstream(recorded: string[], forwardedConnection: string[]): net.Server {
+  return net.createServer((socket) => {
+    let buffer = "";
+    let firstHandled = false;
+    let smuggledSeen = false;
+
+    socket.on("error", () => {});
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("latin1");
+
+      if (!firstHandled) {
+        const headEnd = buffer.indexOf("\r\n\r\n");
+        if (headEnd === -1) {
+          return;
+        }
+        firstHandled = true;
+
+        const lines = buffer.slice(0, headEnd).split("\r\n");
+        const [method, path] = lines[0]!.split(" ");
+        recorded.push(`${method} ${path}`);
+
+        let connection = "";
+        for (let i = 1; i < lines.length; i++) {
+          const idx = lines[i]!.indexOf(":");
+          if (idx !== -1 && lines[i]!.slice(0, idx).trim().toLowerCase() === "connection") {
+            connection = lines[i]!.slice(idx + 1)
+              .trim()
+              .toLowerCase();
+          }
+        }
+        forwardedConnection.push(connection);
+
+        const closeDelimited = connection.includes("close");
+        socket.write(
+          `HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: ${
+            closeDelimited ? "close" : "keep-alive"
+          }\r\n\r\nrewrite-ok`,
+        );
+        if (closeDelimited) {
+          // Honor close: one request per connection, discard any trailing bytes.
+          socket.end();
+          return;
+        }
+      }
+
+      // Keep-alive desync model: treat leftover bytes as pipelined requests.
+      if (firstHandled && !smuggledSeen && buffer.includes(SMUGGLED_MARKER)) {
+        smuggledSeen = true;
+        recorded.push("GET /secret");
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nsecret");
+        socket.end();
+      }
+    });
+  });
+}
+
+/**
+ * Sends a raw smuggling payload: a chunked `method rewritePath` request carrying a
+ * hidden `GET /secret` request inside its single chunk.
+ */
+function sendSmugglingPayload({
+  proxyPort,
+  connectionHeader,
+  method = "DELETE",
+  rewritePath = "/rewrites/poc",
+}: {
+  proxyPort: number;
+  connectionHeader: string;
+  method?: "DELETE" | "OPTIONS";
+  rewritePath?: string;
+}): Promise<void> {
+  const smuggledRequest = Buffer.from(
+    `${SMUGGLED_MARKER}\r\nHost: 127.0.0.1:${proxyPort}\r\n\r\n`,
+    "latin1",
+  );
+  const chunkSize = Buffer.from(
+    `${smuggledRequest.length.toString(16).toUpperCase()}\r\n`,
+    "latin1",
+  );
+
+  const payload = Buffer.concat([
+    Buffer.from(
+      `${method} ${rewritePath} HTTP/1.1\r\nHost: 127.0.0.1:${proxyPort}\r\nTransfer-Encoding: chunked\r\nConnection: ${connectionHeader}\r\n\r\n`,
+      "latin1",
+    ),
+    chunkSize,
+    smuggledRequest,
+    Buffer.from("\r\n0\r\n\r\n", "latin1"),
+  ]);
+
+  return new Promise<void>((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port: proxyPort });
+    let settled = false;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(idleTimer);
+      socket.destroy();
+      resolve();
+    };
+
+    socket.once("connect", () => socket.write(payload));
+    socket.on("data", () => {
+      // Resolve once the upstream has gone idle after the response(s) — long enough
+      // for a keep-alive upstream to have scanned leftover bytes and (without the fix)
+      // executed the smuggled request.
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(finish, 150);
+    });
+    socket.once("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(idleTimer);
+      reject(err);
+    });
+    // Overall cap in case no response ever arrives.
+    socket.setTimeout(2000, finish);
+  });
+}
+
+describe("request smuggling (GHSA-ggv3-7p47-pfv8)", () => {
+  let upstream: net.Server;
+  let proxyServer: http.Server;
+  let proxyPort: number;
+  const recorded: string[] = [];
+  const forwardedConnection: string[] = [];
+
+  beforeAll(async () => {
+    upstream = createLenientUpstream(recorded, forwardedConnection);
+    const upstreamPort = await listenOn(upstream);
+
+    const proxy = httpProxy.createProxyServer({
+      target: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxy.on("error", () => {});
+
+    proxyServer = http.createServer((req, res) => {
+      proxy.web(req, res).catch(() => {});
+    });
+    proxyPort = await listenOn(proxyServer);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  });
+
+  const scenarios: Array<{
+    name: string;
+    connectionHeader: string;
+    method?: "DELETE" | "OPTIONS";
+    rewritePath?: string;
+  }> = [
+    { name: "keep-alive only", connectionHeader: "keep-alive" },
+    { name: "keep-alive, upgrade", connectionHeader: "keep-alive, upgrade" },
+    { name: "Transfer-Encoding, upgrade", connectionHeader: "Transfer-Encoding, upgrade" },
+    {
+      name: "OPTIONS with Transfer-Encoding, upgrade",
+      connectionHeader: "Transfer-Encoding, upgrade",
+      method: "OPTIONS",
+    },
+    {
+      name: "lenient upstream path (non-rfc-strip)",
+      connectionHeader: "keep-alive, upgrade",
+      method: "OPTIONS",
+      rewritePath: "/rewrites/non-rfc-strip",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    it(`does not smuggle a second request with ${scenario.name}`, async () => {
+      recorded.length = 0;
+      forwardedConnection.length = 0;
+
+      const method = scenario.method ?? "DELETE";
+      const rewritePath = scenario.rewritePath ?? "/rewrites/poc";
+
+      await sendSmugglingPayload({
+        proxyPort,
+        connectionHeader: scenario.connectionHeader,
+        method,
+        rewritePath,
+      });
+
+      // The legitimate request reaches the upstream...
+      expect(recorded).toContain(`${method} ${rewritePath}`);
+      // ...but the smuggled request never does.
+      expect(recorded).not.toContain("GET /secret");
+      // ...because the chunked request was forced to close the upstream socket.
+      expect(forwardedConnection[0]).toContain("close");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the **connection-reuse half** of the HTTP request-smuggling fix for [GHSA-ggv3-7p47-pfv8](https://github.com/vercel/next.js/security/advisories/GHSA-ggv3-7p47-pfv8) (CVE-2026-29057). This complements the `deleteLength` desync fix already on `main` (#153).

The upstream Next.js/http-proxy patch had **two** hunks:
1. **Hunk 1 — `deleteLength`** (already fixed in #153): no longer rewrites a chunked `DELETE`/`OPTIONS` into `content-length: 0` while streaming the body — the proxy no longer *manufactures* a desync.
2. **Hunk 2 — `setupOutgoing` (this PR):** force `Connection: close` on the upstream request for any chunked (`transfer-encoding`) request, so the upstream socket is never reused.

### Why Hunk 2 matters for httpxy specifically

A framing desync is only exploitable for cross-user response poisoning if the upstream **keep-alive socket is reused** afterward. httpxy defaults to **keep-alive agents**, so — unlike stock http-proxy (which defaults to no agent → close) — chunked-request sockets were reused by default. That is the exact amplifier Hunk 2 removes. Even though httpxy no longer creates a desync itself, a lenient/legacy upstream (e.g. one that honors `Connection: transfer-encoding` as hop-by-hop, or mishandles chunked framing) could, and the reused socket would let leftover bytes be served as another user's response.

## Change

The hardening now lives in a shared helper, `forceConnectionCloseForTransferEncoding()` (`src/_utils.ts`), which forces `Connection: close` — **regardless of agent** — when the outgoing request carries a `transfer-encoding` header, or its `Connection` header lists `transfer-encoding` as hop-by-hop. This also closes the `Connection: upgrade` + chunked-body bypass vector. Genuine WebSocket upgrades (no `transfer-encoding`) keep their `Connection` header intact.

Crucially, the helper is applied on **every** outgoing-request path, not just `setupOutgoing` — httpxy has three parallel paths that build upstream requests, and all three defaulted to keep-alive socket reuse:

| Path | Location | Coverage |
| --- | --- | --- |
| `setupOutgoing` | `src/_utils.ts` | ProxyServer `web`/`ws` initial requests |
| `proxyFetch` → `_sendRequest` | `src/fetch.ts` | Initial request **and** every `followRedirects` 307/308 replay hop (the helper re-runs on each recursion) |
| `followRedirects` replay | `src/middleware/web-incoming.ts` | ProxyServer 307/308 chunked replay, which builds its request options by hand and bypasses `setupOutgoing` |

Without the last two, a chunked request over `proxyFetch`'s default keep-alive agent, or a chunked ProxyServer request that gets 307/308-redirected with a caller-supplied keep-alive agent, would still return a reusable socket to the pool — leaving the exact smuggling amplifier this PR aims to remove.

## Tests

**Mechanism tests** (assert `Connection: close` is emitted):

- `test/_utils.test.ts` — 4 unit tests: TE forces `close` even with the default keep-alive agent; `Connection: keep-alive, transfer-encoding` forces `close`; `Connection: upgrade` + chunked forces `close`; real WS upgrades are untouched.
- `test/middleware/web-incoming.test.ts` — `#chunked-connection-teardown`: end-to-end raw-socket test asserting the backend actually receives `connection: close` for a chunked request through a default keep-alive proxy. Plus a `#followRedirects` regression asserting the **307 replay** of a chunked request is sent with `connection: close`.
- `test/fetch.test.ts` — `proxyFetch` regressions: chunked request over a keep-alive agent forces `close`; `Connection` hop-by-hop marker forces `close`; 307 replay forces `close` and preserves the body; a non-chunked request keeps `connection` intact.

**End-to-end outcome test** (`test/request-smuggling.test.ts`, ported from the upstream [vercel/next.js `rewrite-request-smuggling` suite](https://github.com/vercel/next.js/blob/7da98e13183864ebc23ffe7aaec07c566c83a6a5/test/production/rewrite-request-smuggling/rewrite-request-smuggling.test.ts)):

Sends a raw crafted chunked request that hides a second `GET /secret` request inside its body, through an httpxy proxy fronting a deliberately **lenient, desync-prone upstream** (pipelines on keep-alive, honors `Connection: close`), and asserts the smuggled request **never reaches the upstream** — across the same `Connection`-header permutations and methods as upstream:

| Scenario | `Connection` header | Method |
| --- | --- | --- |
| keep-alive only | `keep-alive` | DELETE |
| keep-alive + upgrade | `keep-alive, upgrade` | DELETE |
| transfer-encoding + upgrade | `Transfer-Encoding, upgrade` | DELETE |
| OPTIONS + transfer-encoding + upgrade | `Transfer-Encoding, upgrade` | OPTIONS |
| lenient upstream (non-rfc TE strip) | `keep-alive, upgrade` | OPTIONS |

> The upstream suite's 6th scenario (absolute-URL upgrade → SSRF) is **N/A for httpxy**: it targets Next.js's rewrite engine, which can route by the request URL's host. httpxy's ws/upgrade path always resolves to the configured `options.target` via `setupOutgoing` — an absolute URL only affects the outgoing *path* (`toProxy`), never the destination host — so there is no URL-driven routing to exploit.

All new tests were verified to **fail without this change** (the smuggled `GET /secret` reaches the upstream) and pass with it. Full suite (lint + typecheck + 314 tests) is green.

## Docs

Updated `AGENTS.md`: corrected the stale `deleteLength` description, documented the keep-alive default and the TE → `Connection: close` rule, documented the shared helper with the three outgoing paths it now covers, and listed the new `request-smuggling.test.ts` end-to-end suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of chunked requests so upstream connections now use `Connection: close` when needed, helping prevent request-smuggling issues.
  * Preserved legitimate upgrade/WebSocket behavior while keeping the original connection header intact when no transfer encoding is present.
  * Clarified HTTP behavior for `DELETE` and `OPTIONS` requests: `content-length: 0` is only added when no body-related headers are already set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
