### PR TITLE
fix: drain client body when upstream responds before request body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Returns Promise<Socket> (the upstream proxy socket)
 - `proxyRes` event fires only for the final (non-redirect) response; `proxyReq` fires for each request including redirects.
 - Sensitive headers (`authorization`, `cookie`) are stripped on cross-origin redirects.
 - When `followRedirects` is enabled, the request body is tee'd (written to proxy request and buffered simultaneously) rather than piped.
+- When the upstream responds before the request body is fully written, `drainAfterEarlyResponse()` (`src/_utils.ts`, called on every `response` in `proxy.web` and `proxyFetch`) unpipes and dumps the rest of the incoming body so the client connection stays usable, and destroys the upstream request once its response closes. Coverage: `test/early-response.test.ts`.
 - Without `followRedirects`, the incoming request is piped into the outgoing request **immediately**, without waiting for the upstream socket to emit `connect`. `ClientRequest` buffers writes issued before the socket connects, so the deferral is unnecessary — and it deadlocks with mocked sockets from request interceptors (msw/`@mswjs/interceptors`, nock), which only emit `connect` _after_ the outgoing request has been fully written (unjs/httpxy#166). Regression coverage: `#stream with mocked sockets` in `test/middleware/web-incoming.test.ts`.
 
 ### WebSocket middleware semantics
@@ -158,6 +159,7 @@ test/
 ├── http-proxy.test.ts             — Forward, target, WebSocket, socket.io, SSE, timeouts, error events
 ├── https-proxy.test.ts            — HTTPS targets, SSL certs, certificate validation
 ├── _utils.test.ts                 — setupOutgoing, setupSocket, path joining, auth, changeOrigin
+├── early-response.test.ts         — Upstream replies before the request body is fully written (proxyFetch + proxy.web)
 ├── request-smuggling.test.ts      — End-to-end GHSA-ggv3-7p47-pfv8 reproduction (chunked payload hiding a smuggled request; asserts it never reaches a lenient upstream), ported from vercel/next.js
 ├── types.test-d.ts                — TypeScript type assertions (vitest typecheck)
 └── middleware/

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,6 +1,7 @@
 import httpNative from "node:http";
 import httpsNative from "node:https";
 import net from "node:net";
+import type { Readable } from "node:stream";
 import type { ProxyAddr, ProxyServerOptions, ProxyTarget, ProxyTargetDetailed } from "./types.ts";
 import type { Http2ServerRequest } from "node:http2";
 
@@ -52,6 +53,31 @@ export function forceConnectionCloseForTransferEncoding(
   if (carriesTransferEncoding || connectionMarksTransferEncoding) {
     headers.connection = "close";
   }
+}
+
+/**
+ * `ClientRequest` stops flushing body writes once it has a complete response, so a
+ * source still piped into it would never drain. Dump the rest of the source and tear
+ * down the half-written upstream request once its response closes (a keep-alive agent
+ * never returns an unfinished request's socket to the pool).
+ */
+export function drainAfterEarlyResponse(
+  proxyReq: httpNative.ClientRequest,
+  proxyRes: httpNative.IncomingMessage,
+  source?: Readable,
+): void {
+  if (proxyReq.writableFinished) {
+    return;
+  }
+  if (source) {
+    source.unpipe(proxyReq);
+    source.resume();
+  }
+  proxyRes.once("close", () => {
+    if (!proxyReq.writableFinished) {
+      proxyReq.destroy();
+    }
+  });
 }
 
 /**

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -5,6 +5,7 @@ import { Readable } from "node:stream";
 import type { ProxyAddr } from "./types.ts";
 import {
   defaultAgents,
+  drainAfterEarlyResponse,
   forceConnectionCloseForTransferEncoding,
   isSSL,
   joinURL,
@@ -326,6 +327,7 @@ function _sendRequest(
 
     const req = doRequest(reqOpts, (res) => {
       const statusCode = res.statusCode!;
+      drainAfterEarlyResponse(req, res, body instanceof Readable ? body : undefined);
 
       if (
         opts.maxRedirects > 0 &&

--- a/src/middleware/web-incoming.ts
+++ b/src/middleware/web-incoming.ts
@@ -2,7 +2,9 @@ import type { ClientRequest, IncomingMessage, ServerResponse } from "node:http";
 import type { ProxyTargetDetailed } from "../types.ts";
 import nodeHTTP from "node:http";
 import nodeHTTPS from "node:https";
+import type { Readable } from "node:stream";
 import {
+  drainAfterEarlyResponse,
   forceConnectionCloseForTransferEncoding,
   getPort,
   hasEncryptedConnection,
@@ -314,6 +316,7 @@ export const stream = defineProxyMiddleware((req, res, options, server, head, ca
   }
 
   proxyReq.on("response", function (proxyRes) {
+    drainAfterEarlyResponse(proxyReq, proxyRes, (options.buffer as Readable) || req);
     handleResponse(proxyRes, 0, options.target as URL);
   });
 });

--- a/test/early-response.test.ts
+++ b/test/early-response.test.ts
@@ -1,0 +1,123 @@
+import { Agent, createServer, type Server } from "node:http";
+import { connect } from "node:net";
+import { Readable } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { createProxyServer, proxyFetch } from "../src/index.ts";
+import { listenOn } from "./_utils.ts";
+
+const LIMIT = 64 * 1024;
+const TOTAL = 8 * 1024 * 1024;
+
+let upstream: Server;
+let upstreamPort: number;
+
+beforeAll(async () => {
+  upstream = createServer((req, res) => {
+    if (Number(req.headers["content-length"]) > LIMIT) {
+      res.writeHead(413, { "content-type": "text/plain" });
+      res.end("too large");
+      return;
+    }
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+  });
+  upstreamPort = await listenOn(upstream);
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => upstream.close(() => r()));
+});
+
+interface Outcome {
+  statuses: string[];
+  written: number;
+  error?: string;
+}
+
+function uploadThenPipeline(port: number): Promise<Outcome> {
+  return new Promise((resolve) => {
+    const chunk = Buffer.alloc(64 * 1024, 0x78);
+    const socket = connect(port, "127.0.0.1");
+    let written = 0;
+    let received = "";
+    let error: string | undefined;
+    const statuses = () => [...received.matchAll(/^HTTP\/1\.1 (\d{3})/gm)].map((m) => m[1]!);
+    const finish = () => resolve({ statuses: statuses(), written, error });
+    socket.on("data", (d) => {
+      received += d.toString("latin1");
+      if (statuses().length === 2) {
+        socket.end();
+      }
+    });
+    socket.on("error", (err: NodeJS.ErrnoException) => (error = err.code));
+    socket.on("close", finish);
+    const pump = () => {
+      while (written < TOTAL) {
+        written += chunk.length;
+        if (!socket.write(chunk)) {
+          socket.once("drain", pump);
+          return;
+        }
+      }
+      socket.write("GET /small HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    };
+    socket.on("connect", () => {
+      socket.write(`POST /big HTTP/1.1\r\nHost: localhost\r\nContent-Length: ${TOTAL}\r\n\r\n`);
+      pump();
+    });
+    setTimeout(() => socket.destroy(), 10_000).unref();
+  });
+}
+
+function busySockets(agent: Agent) {
+  return Object.values(agent.sockets).reduce((n, list) => n + (list?.length ?? 0), 0);
+}
+
+async function expectDrained(outcome: Outcome, agent: Agent) {
+  expect(outcome.error).toBeUndefined();
+  expect(outcome.written).toBe(TOTAL);
+  expect(outcome.statuses).toEqual(["413", "200"]);
+  await vi.waitFor(() => expect(busySockets(agent)).toBe(0));
+  agent.destroy();
+}
+
+describe("upstream responds before the request body is fully written", () => {
+  it("proxyFetch keeps draining the client body and the connection stays usable", async () => {
+    const agent = new Agent({ keepAlive: true });
+    const front = createServer(async (req, res) => {
+      const body = req.method === "POST" ? Readable.toWeb(req) : undefined;
+      const upstreamRes = await proxyFetch(
+        `http://127.0.0.1:${upstreamPort}`,
+        `http://localhost${req.url}`,
+        { method: req.method, headers: req.headers as Record<string, string>, body: body as any },
+        { agent },
+      );
+      res.writeHead(upstreamRes.status, Object.fromEntries(upstreamRes.headers));
+      res.end(await upstreamRes.text());
+    });
+    const port = await listenOn(front);
+    try {
+      await expectDrained(await uploadThenPipeline(port), agent);
+    } finally {
+      await new Promise<void>((r) => front.close(() => r()));
+    }
+  });
+
+  it("proxy.web keeps draining the client body and the connection stays usable", async () => {
+    const agent = new Agent({ keepAlive: true });
+    const proxy = createProxyServer({ target: `http://127.0.0.1:${upstreamPort}`, agent });
+    const front = createServer((req, res) => {
+      proxy.web(req, res);
+    });
+    const port = await listenOn(front);
+    try {
+      await expectDrained(await uploadThenPipeline(port), agent);
+    } finally {
+      await new Promise<void>((r) => front.close(() => r()));
+    }
+  });
+});


### PR DESCRIPTION
context: flaky test in nuxt (see https://github.com/nuxt/nuxt/pull/36320), which was related to the dev server proxying to nitro worker with `proxyFetch`.

we reply 413 when we have a payload that's oversized for an island, but we didn't drain the rest of the body. we're doing that now (because we should anyway, in production), but I think that probably also needs to live here....

this PR adds a small helper that runs on every upstream `response` to clean up an incoming body when an outgoing request isn't `writableFinished` yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented uploads from stalling when upstream servers respond before request bodies finish.
  - Ensured complete request bodies are forwarded when upstream headers arrive early.
  - Kept connections available for subsequent requests and properly drained incoming data after early responses.

- **Tests**
  - Added coverage for large uploads, early rejection responses, early headers, and keep-alive connection reuse.

- **Documentation**
  - Clarified early-response handling behavior and coverage for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->