### PR TITLE
feat(ws): add an upgrade establishment timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ Returns Promise<Socket> (the upstream proxy socket)
 - WS requests must be `GET` with `upgrade: websocket`; otherwise socket is destroyed and the chain stops.
 - `proxyReqWs`, `open`, `close`, and deprecated `proxySocket` events are part of tested flow.
 - Upgrade response headers preserve repeated headers like multiple `Set-Cookie` values.
+- `establishmentTimeout` sets an optional total deadline until upstream upgrade or final HTTP response headers, including connection setup. It is shared with `proxyUpgrade`. Omitted, non-positive, and non-finite values disable it; larger finite values are capped at `2147483647` ms. Expiry reports `ERR_UPSTREAM_UPGRADE_TIMEOUT` with `statusCode: 504` and destroys the upstream request and client socket, without writing an HTTP response. The timer and its establishment-only listeners are removed on completion, request error/close, or downstream close. An enabled deadline also cancels the pending upstream request when the downstream socket closes; it does not change post-upgrade socket ownership or limit response bodies.
+- While the deadline is active, timeout, downstream cancellation, and downstream socket errors report failure directly before the wrapper's socket listeners settle `ProxyServer.ws()`, including while a custom agent has no available socket. Later request errors do not repeat an establishment failure. With an error listener, middleware emits the error and resolves; without one, it rejects. Destroyed queued requests remain caller-agent-owned until capacity returns; the proxy does not edit `agent.requests`. Regression coverage includes queued timeout/cancellation/socket error, both error-listener modes, and late agent release without transmitting the canceled upgrade.
 
 ### Outgoing response semantics
 
@@ -147,6 +149,7 @@ Returns Promise<Socket> (the upstream proxy socket)
 - Returns `Promise<Socket>` — resolves with the upstream proxy socket on successful upgrade, rejects on connection or socket error.
 - If the upstream responds without upgrading (e.g., 404), the response is relayed to the client socket.
 - Uses `setupOutgoing()` and `setupSocket()` from shared utils, consistent with `ProxyServer.ws()`.
+- Supports the same opt-in `establishmentTimeout` as `ProxyServer.ws()`, implemented by `src/_ws-timeout.ts` and covered for both APIs in `test/ws-timeout.test.ts`.
 
 ## Tests (`test/`)
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,16 @@ server.on("upgrade", (req, socket, head) => {
   proxyUpgrade({ host: "127.0.0.1", port: 8080 }, req, socket, head, {
     // changeOrigin: true, // rewrite Host header
     // xfwd: false, // disable x-forwarded-* headers (enabled by default)
+    // establishmentTimeout: 5000, // wait up to 5 seconds for upstream response headers
   });
 });
 ```
+
+`establishmentTimeout` is an optional deadline in milliseconds for receiving the upstream upgrade or a final HTTP response's headers. It starts before the request is sent and includes connection setup. Informational responses and partial headers do not reset it. Omitted, non-positive, and non-finite values disable the deadline; values above `2147483647` are capped at that limit.
+
+On expiry, the proxy destroys its upstream request and the client socket, and reports an error with `code: "ERR_UPSTREAM_UPGRADE_TIMEOUT"` and `statusCode: 504`. It does not write an HTTP 504 response. With the deadline enabled, closing the client socket also cancels the pending upstream request. The timer stops on an upstream error, final response headers, or upgrade, so it does not limit the lifetime of an established WebSocket or a non-upgrade response body.
+
+Timeout, cancellation, and downstream socket errors are reported even while a custom agent is waiting for a socket. With the deadline active, `ProxyServer.ws()` emits the error and resolves if an error listener handles it; otherwise it rejects. The agent may retain the destroyed request in its queue until capacity becomes available; the proxy does not modify the agent's queue.
 
 ## Proxy Server
 
@@ -129,6 +136,7 @@ server.listen(3000, () => {
 | `cookiePathRewrite`     | `false \| string \| object`            | `false`    | Rewrite path of `Set-Cookie` headers                                        |
 | `headers`               | `object`                               | —          | Extra headers to add to target requests                                     |
 | `proxyTimeout`          | `number`                               | `120000`   | Timeout (ms) for the proxy request to the target                            |
+| `establishmentTimeout`  | `number`                               | —          | Deadline (ms) for WebSocket upstream response headers; see Proxy Upgrade    |
 | `timeout`               | `number`                               | —          | Timeout (ms) for the incoming request                                       |
 | `selfHandleResponse`    | `boolean`                              | `false`    | Disable automatic response piping (handle `proxyRes` yourself)              |
 | `followRedirects`       | `boolean \| number`                    | `false`    | Follow HTTP redirects from target. `true` = max 5 hops; number = custom max |

--- a/src/_ws-timeout.ts
+++ b/src/_ws-timeout.ts
@@ -1,0 +1,60 @@
+import type { ClientRequest } from "node:http";
+import type { Duplex } from "node:stream";
+
+export function setUpgradeTimeout(
+  proxyReq: ClientRequest,
+  socket: Duplex,
+  timeout: number | undefined,
+  onError: (error: Error) => void,
+): void {
+  if (!timeout || timeout <= 0 || !Number.isFinite(timeout)) {
+    return;
+  }
+
+  const timer = setTimeout(
+    () => {
+      const error = Object.assign(new Error("Upstream WebSocket upgrade timed out"), {
+        code: "ERR_UPSTREAM_UPGRADE_TIMEOUT",
+        statusCode: 504,
+      });
+      fail(error);
+    },
+    Math.min(timeout, 2_147_483_647),
+  );
+  timer.unref();
+
+  proxyReq.once("response", clear);
+  proxyReq.once("upgrade", clear);
+  proxyReq.once("error", clear);
+  proxyReq.once("close", clear);
+  socket.prependOnceListener("error", fail);
+  socket.prependOnceListener("close", onSocketClose);
+
+  if (socket.destroyed) {
+    onSocketClose();
+  }
+
+  function clear() {
+    clearTimeout(timer);
+    proxyReq.removeListener("response", clear);
+    proxyReq.removeListener("upgrade", clear);
+    proxyReq.removeListener("error", clear);
+    proxyReq.removeListener("close", clear);
+    socket.removeListener("error", fail);
+    socket.removeListener("close", onSocketClose);
+  }
+
+  function onSocketClose() {
+    fail(socket.errored || Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+  }
+
+  function fail(error: Error) {
+    clear();
+    try {
+      onError(error);
+    } finally {
+      proxyReq.destroy(error);
+      socket.destroy();
+    }
+  }
+}

--- a/src/middleware/ws-incoming.ts
+++ b/src/middleware/ws-incoming.ts
@@ -3,6 +3,7 @@ import nodeHTTPS from "node:https";
 import type { Socket } from "node:net";
 import { type ProxyMiddleware, defineProxyMiddleware } from "./_utils.ts";
 import { getPort, hasEncryptedConnection, isSSL, setupOutgoing, setupSocket } from "../_utils.ts";
+import { setUpgradeTimeout } from "../_ws-timeout.ts";
 
 /**
  * WebSocket requests must have the `GET` method and
@@ -48,6 +49,7 @@ export const XHeaders = defineProxyMiddleware<Socket>((req, socket, options) => 
  */
 export const stream = defineProxyMiddleware<Socket>(
   (req, socket, options, server, head, callback) => {
+    let establishmentFailed = false;
     const createHttpHeader = function (line: string, headers: nodeHTTP.OutgoingHttpHeaders) {
       return (
         Object.keys(headers)
@@ -152,25 +154,29 @@ export const stream = defineProxyMiddleware<Socket>(
       server.emit("proxySocket", proxySocket); // DEPRECATED.
     });
 
+    setUpgradeTimeout(proxyReq, socket, options.establishmentTimeout, (error) => {
+      establishmentFailed = true;
+      reportError(error);
+    });
     proxyReq.end(); // XXX: CHECK IF THIS IS THIS CORRECT
     // return;
 
     function onSocketError(err: Error) {
-      if (callback) {
-        callback(err, req, socket);
-      } else {
-        server.emit("error", err, req, socket);
-      }
+      if (!establishmentFailed) reportError(err);
       proxyReq.destroy();
     }
 
     function onOutgoingError(err: Error) {
+      if (!establishmentFailed) reportError(err);
+      socket.end();
+    }
+
+    function reportError(err: Error) {
       if (callback) {
         callback(err, req, socket);
       } else {
         server.emit("error", err, req, socket);
       }
-      socket.end();
     }
   },
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,8 @@ export interface ProxyServerOptions {
   headers?: { [header: string]: string };
   /** Timeout (in milliseconds) when proxy receives no response from target. Default: 120000 (2 minutes) */
   proxyTimeout?: number;
+  /** Total time in milliseconds to receive upstream WebSocket response headers or an upgrade. Omitted, non-positive, and non-finite values disable the deadline. */
+  establishmentTimeout?: number;
   /** Timeout (in milliseconds) for incoming requests */
   timeout?: number;
   /** If set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the proxyRes event */

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -4,6 +4,7 @@ import { request as httpsRequest } from "node:https";
 import type { Duplex } from "node:stream";
 import type { Socket } from "node:net";
 import type { ProxyAddr } from "./types.ts";
+import { setUpgradeTimeout } from "./_ws-timeout.ts";
 import {
   getPort,
   hasEncryptedConnection,
@@ -17,6 +18,11 @@ import {
  * Options for {@link proxyUpgrade}.
  */
 export interface ProxyUpgradeOptions {
+  /**
+   * Total time in milliseconds to receive upstream response headers or an upgrade.
+   * Omitted, non-positive, and non-finite values disable the deadline.
+   */
+  establishmentTimeout?: number;
   /**
    * Add `x-forwarded-for`, `x-forwarded-port`, and `x-forwarded-proto` headers.
    * Default: `true`.
@@ -197,6 +203,7 @@ export function proxyUpgrade(
       resolve(proxySocket);
     });
 
+    setUpgradeTimeout(proxyReq, sock, opts?.establishmentTimeout, onOutgoingError);
     proxyReq.end();
 
     function onSocketError(err: Error) {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -34,6 +34,11 @@ describe("httpxy types", () => {
       prependPath: false,
       ignorePath: true,
       toProxy: true,
+      establishmentTimeout: 5000,
     });
+  });
+
+  it("accepts an upgrade establishment deadline on ProxyServer", () => {
+    assertType<ProxyServer>(new ProxyServer({ establishmentTimeout: 5000 }));
   });
 });

--- a/test/ws-timeout.test.ts
+++ b/test/ws-timeout.test.ts
@@ -1,0 +1,310 @@
+import { once } from "node:events";
+import { Agent, createServer, request, type Server, type ServerResponse } from "node:http";
+import { connect, type AddressInfo, type Socket } from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { createProxyServer } from "../src/server.ts";
+import { proxyUpgrade } from "../src/ws.ts";
+
+const servers = new Set<Server>();
+const sockets = new Set<Socket>();
+
+afterEach(async () => {
+  for (const socket of sockets) socket.destroy();
+  await Promise.all(
+    [...servers].map((server) => new Promise<void>((done) => server.close(() => done()))),
+  );
+  sockets.clear();
+  servers.clear();
+});
+
+async function listen(server: Server) {
+  servers.add(server);
+  server.on("connection", (socket) => sockets.add(socket));
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return (server.address() as AddressInfo).port;
+}
+
+function getBody(port: number, agent: Agent) {
+  return new Promise<string>((resolve, reject) => {
+    const req = request({ host: "127.0.0.1", port, agent }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => resolve(body));
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+for (const mode of ["proxyUpgrade", "ProxyServer.ws"] as const) {
+  describe(`${mode} establishmentTimeout`, () => {
+    async function start(
+      target: Server | number,
+      establishmentTimeout: number | undefined,
+      onProxy?: (socket: Socket) => void,
+      handleError = true,
+      agent?: Agent,
+    ) {
+      const targetPort = typeof target === "number" ? target : await listen(target);
+      const options = { establishmentTimeout, agent };
+      const proxy = createProxyServer({ target: `http://127.0.0.1:${targetPort}`, ...options });
+      const errors: Error[] = [];
+      const failed = Promise.withResolvers<Error>();
+      const downstream = Promise.withResolvers<Socket>();
+      const settled = Promise.withResolvers<"resolved" | Error>();
+      if (mode === "ProxyServer.ws" && handleError) {
+        proxy.on("error", (error) => {
+          errors.push(error);
+          failed.resolve(error);
+        });
+      }
+      const server = createServer();
+      server.on("upgrade", (req, socket, head) => {
+        downstream.resolve(socket as Socket);
+        onProxy?.(socket as Socket);
+        const result =
+          mode === "proxyUpgrade"
+            ? proxyUpgrade(`http://127.0.0.1:${targetPort}`, req, socket, head, options)
+            : proxy.ws(req, socket as Socket, {}, head);
+        result.then(
+          () => settled.resolve("resolved"),
+          (error) => {
+            errors.push(error);
+            failed.resolve(error);
+            settled.resolve(error);
+          },
+        );
+      });
+      const port = await listen(server);
+      const client = connect(port, "127.0.0.1");
+      sockets.add(client);
+      client.on("error", () => {});
+      let response = "";
+      client.on("data", (chunk) => {
+        response += chunk.toString();
+      });
+      const closed = once(client, "close");
+      await once(client, "connect");
+      client.write(
+        `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nConnection: Upgrade\r\n` +
+          "Upgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+          "Sec-WebSocket-Version: 13\r\n\r\n",
+      );
+      return {
+        client,
+        errors,
+        failed: failed.promise,
+        downstream: downstream.promise,
+        settled: settled.promise,
+        closed,
+        response: () => response,
+      };
+    }
+
+    it("times out a silent upstream and closes both connections once", async () => {
+      const target = createServer();
+      const connected = once(target, "upgrade");
+      const fixture = await start(target, 40);
+      const [, upstream] = await connected;
+      const upstreamClosed = once(upstream, "close");
+      upstream.once("end", () => upstream.end());
+      upstream.resume();
+      const result = await Promise.race([fixture.failed, delay(400, "still pending")]);
+      expect(result).toMatchObject({ code: "ERR_UPSTREAM_UPGRADE_TIMEOUT", statusCode: 504 });
+      await Promise.all([fixture.closed, upstreamClosed]);
+      await delay(60);
+      expect(fixture.errors).toHaveLength(1);
+      expect(fixture.response()).toBe("");
+    });
+
+    describe.each([true, false])("queued requests with handleError=%s", (handleError) => {
+      it.each(["timeout", "downstream close", "downstream error"])(
+        "reports %s before an agent socket is available",
+        async (failure) => {
+          const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+          const held = Promise.withResolvers<ServerResponse>();
+          let requests = 0;
+          let upgrades = 0;
+          const target = createServer((_req, res) => {
+            if (++requests === 1) held.resolve(res);
+            else res.end("next request");
+          });
+          target.on("upgrade", (_req, socket) => {
+            upgrades++;
+            socket.destroy();
+          });
+          const targetPort = await listen(target);
+          const occupying = getBody(targetPort, agent);
+          const heldResponse = await held.promise;
+          try {
+            const fixture = await start(
+              targetPort,
+              failure === "timeout" ? 40 : 1000,
+              undefined,
+              handleError,
+              agent,
+            );
+            const downstream = await fixture.downstream;
+            expect(Object.values(agent.requests).flat()).toHaveLength(1);
+            const clientError = Object.assign(new Error("client reset"), { code: "ECONNRESET" });
+            if (failure !== "timeout") {
+              downstream.destroy(failure === "downstream error" ? clientError : undefined);
+            }
+
+            const error = await Promise.race([fixture.failed, delay(400, "still pending")]);
+            expect(error).toMatchObject({
+              code: failure === "timeout" ? "ERR_UPSTREAM_UPGRADE_TIMEOUT" : "ECONNRESET",
+            });
+            if (failure === "timeout") expect(error).toMatchObject({ statusCode: 504 });
+            if (failure === "downstream error") expect(error).toBe(clientError);
+            expect(fixture.errors).toHaveLength(1);
+            expect(await fixture.settled).toBe(
+              mode === "ProxyServer.ws" && handleError ? "resolved" : error,
+            );
+            await fixture.closed;
+            expect(fixture.response()).toBe("");
+            expect(fixture.errors).toHaveLength(1);
+
+            heldResponse.end("released");
+            expect(await occupying).toBe("released");
+            expect(await getBody(targetPort, agent)).toBe("next request");
+            expect(upgrades).toBe(0);
+            expect(fixture.errors).toHaveLength(1);
+          } finally {
+            heldResponse.end();
+            await occupying;
+            agent.destroy();
+          }
+        },
+      );
+    });
+
+    it("does not extend the deadline for informational responses or partial headers", async () => {
+      const target = createServer();
+      target.on("upgrade", (_req, socket) => {
+        socket.on("error", () => {});
+        socket.write("HTTP/1.1 103 Early Hints\r\n\r\nHTTP/1.1 401 Unauthorized\r\nX-Slow: ");
+        const timer = setInterval(() => socket.write("x"), 10);
+        socket.once("close", () => clearInterval(timer));
+        socket.once("end", () => socket.end());
+        socket.resume();
+      });
+      const fixture = await start(target, 80);
+      expect(await fixture.failed).toMatchObject({ code: "ERR_UPSTREAM_UPGRADE_TIMEOUT" });
+      await fixture.closed;
+      expect(fixture.response()).toBe("");
+    });
+
+    if (mode === "ProxyServer.ws") {
+      it("rejects the promise when no error listener handles the timeout", async () => {
+        const target = createServer();
+        target.on("upgrade", (_req, socket) => socket.resume());
+        const fixture = await start(target, 40, undefined, false);
+        expect(await fixture.failed).toMatchObject({
+          code: "ERR_UPSTREAM_UPGRADE_TIMEOUT",
+          statusCode: 504,
+        });
+        await fixture.closed;
+        expect(fixture.errors).toHaveLength(1);
+      });
+    }
+
+    it("keeps an upgraded tunnel usable after the deadline", async () => {
+      const target = createServer();
+      target.on("upgrade", (_req, socket) => {
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n" +
+            "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+        );
+        socket.pipe(socket);
+      });
+      const fixture = await start(target, 80);
+      await once(fixture.client, "data");
+      await delay(120);
+      const echoed = once(fixture.client, "data");
+      fixture.client.write("still connected");
+      expect((await echoed)[0].toString()).toBe("still connected");
+      expect(fixture.errors).toEqual([]);
+    });
+
+    it("stops the deadline at non-upgrade headers without limiting the response body", async () => {
+      const target = createServer();
+      const response = Promise.withResolvers<() => void>();
+      target.on("request", (_req, res) => {
+        res.writeHead(401, { "Content-Length": "4", Connection: "close" });
+        res.write("a");
+        response.resolve(() => res.end("bcd"));
+      });
+      const fixture = await start(target, 80);
+      const finish = await response.promise;
+      await once(fixture.client, "data");
+      await delay(120);
+      expect(fixture.client.destroyed).toBe(false);
+      finish();
+      await fixture.closed;
+      expect(fixture.response()).toContain("401 Unauthorized");
+      expect(fixture.response()).toContain("abcd");
+      expect(fixture.errors).toHaveLength(mode === "proxyUpgrade" ? 1 : 0);
+      expect(
+        fixture.errors.some(
+          (error) => "code" in error && error.code === "ERR_UPSTREAM_UPGRADE_TIMEOUT",
+        ),
+      ).toBe(false);
+    });
+
+    it("clears the deadline on an earlier upstream error", async () => {
+      const target = createServer();
+      target.on("upgrade", (_req, socket) => socket.destroy());
+      const fixture = await start(target, 80);
+      expect(await fixture.failed).toMatchObject({ code: "ECONNRESET" });
+      await fixture.closed;
+      await delay(120);
+      expect(fixture.errors).toHaveLength(1);
+    });
+
+    it("cancels the pending upstream when the downstream socket closes", async () => {
+      const target = createServer();
+      const connected = once(target, "upgrade");
+      const fixture = await start(target, 80);
+      const [, upstream] = await connected;
+      const upstreamClosed = once(upstream, "close");
+      upstream.once("end", () => upstream.end());
+      upstream.resume();
+      (await fixture.downstream).destroy();
+      await Promise.all([fixture.closed, upstreamClosed]);
+      expect(await fixture.failed).toMatchObject({ code: "ECONNRESET" });
+      await delay(120);
+      expect(fixture.errors).toHaveLength(1);
+    });
+
+    it("cancels the upstream request if the downstream socket is already destroyed", async () => {
+      const target = createServer();
+      let requests = 0;
+      target.on("upgrade", () => {
+        requests++;
+      });
+      const fixture = await start(target, 80, (socket) => socket.destroy());
+      expect(await fixture.failed).toMatchObject({ code: "ECONNRESET" });
+      await fixture.closed;
+      await delay(120);
+      expect(requests).toBe(0);
+      expect(fixture.errors).toHaveLength(1);
+    });
+
+    it.each([undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 31])(
+      "does not immediately time out with establishmentTimeout=%s",
+      async (timeout) => {
+        const target = createServer();
+        const connected = once(target, "upgrade");
+        const fixture = await start(target, timeout);
+        await connected;
+        await delay(40);
+        expect(fixture.client.destroyed).toBe(false);
+        expect(fixture.errors).toEqual([]);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds optional `establishmentTimeout` support to `proxyUpgrade` and `ProxyServer.ws()`.

The deadline covers connection setup through upstream upgrade or final response headers. It is disabled by default and does not limit established tunnels or non-upgrade response bodies.

Timeouts report `ERR_UPSTREAM_UPGRADE_TIMEOUT` with `statusCode: 504` and destroy the pending upstream request and client socket without writing an HTTP 504 response. Failure is reported even when a custom agent is waiting for a socket. Downstream cancellation preserves the original error where available, and deferred request errors do not cause duplicate delivery.

## Verification

- `pnpm vitest run test/ws-timeout.test.ts`
- `pnpm test`
- `pnpm build`
- Focused tests pass on Node 24.11.1 and 26.5.0.
- Regression coverage includes saturated agents, cancellation, error-listener behavior, late agent release, and established tunnels surviving beyond the deadline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional WebSocket establishment timeout for proxy upgrades.
  * Configurable deadlines now cover receiving upstream response headers or a successful upgrade.
  * Timeout failures report a 504 error and clean up affected connections.
  * Invalid, non-positive, or non-finite values disable the deadline.

* **Documentation**
  * Added configuration guidance, behavior details, and examples for the new timeout option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->